### PR TITLE
Fix typo that crashed cluster creation + GUID tag tracking opt-out

### DIFF
--- a/python-clusters/create-aks-cluster/cluster.py
+++ b/python-clusters/create-aks-cluster/cluster.py
@@ -83,13 +83,9 @@ class MyCluster(Cluster):
             node_pool_builder.with_vm_size(node_pool_conf.get("vmSize", None))
             vnet = node_pool_conf.get("vnet", None)
             subnet = node_pool_conf.get("subnet", None)
-            subnet_id = get_subnet_id(connection_info=connection_info,
-                                      resource_group=resource_group,
-                                      vnet=vnet,
-                                      subnet=subnet)
             node_pool_builder.with_network(inherit_from_host=node_pool_conf.get("useSameNetworkAsDSSHost"),
                                            cluster_vnet=vnet,
-                                           cluster_subnet_id=subnet_id,
+                                           cluster_subnet=subnet,
                                            connection_info=connection_info,
                                            credentials=credentials,
                                            resource_group=resource_group)

--- a/python-clusters/create-aks-cluster/cluster.py
+++ b/python-clusters/create-aks-cluster/cluster.py
@@ -8,7 +8,7 @@ from azure.mgmt.containerservice.models import ManagedClusterAgentPoolProfile
 from azure.mgmt.containerservice.models import ContainerServiceVMSizeTypes
 from msrestazure.azure_exceptions import CloudError
 
-from dku_utils.access import _is_none_or_blank
+from dku_utils.access import _is_none_or_blank, _has_not_blank_property
 from dku_utils.cluster import make_overrides, get_cluster_from_connection_info
 from dku_azure.auth import get_credentials_from_connection_info
 from dku_azure.clusters import ClusterBuilder
@@ -35,7 +35,9 @@ class MyCluster(Cluster):
         clusters_client = ContainerServiceClient(credentials, subscription_id)
         
         # Credit the cluster to DATAIKU
-        clusters_client.config.add_user_agent('pid-fd3813c7-273c-5eec-9221-77323f62a148')
+        if _has_not_blank_property(os.environ, "DISABLE_AZURE_TRACKING") and os.environ["DISABLE_AZURE_TRACKING"] is not true:
+            logging.info("Adding Dataiku GUID")
+            clusters_client.config.add_user_agent('pid-fd3813c7-273c-5eec-9221-77323f62a148')
         
         resource_group_name = self.config.get('resourceGroup', None)
         # TODO: Auto detection

--- a/python-clusters/create-aks-cluster/cluster.py
+++ b/python-clusters/create-aks-cluster/cluster.py
@@ -35,8 +35,9 @@ class MyCluster(Cluster):
         clusters_client = ContainerServiceClient(credentials, subscription_id)
         
         # Credit the cluster to DATAIKU
-        if _has_not_blank_property(os.environ, "DISABLE_AZURE_TRACKING") and os.environ["DISABLE_AZURE_TRACKING"] is not true:
-            logging.info("Adding Dataiku GUID")
+        if _has_not_blank_property(os.environ, "DISABLE_AZURE_TRACKING") and os.environ["DISABLE_AZURE_TRACKING"] == "1":
+            logging.info("Azure tracking is disabled")
+        else:
             clusters_client.config.add_user_agent('pid-fd3813c7-273c-5eec-9221-77323f62a148')
         
         resource_group_name = self.config.get('resourceGroup', None)

--- a/python-lib/dku_azure/clusters.py
+++ b/python-lib/dku_azure/clusters.py
@@ -124,14 +124,14 @@ class NodePoolBuilder(object):
             self.gpu = False
         return self
 
-    def with_network(self, inherit_from_host, cluster_vnet, cluster_subnet_id, connection_info, credentials, resource_group):
+    def with_network(self, inherit_from_host, cluster_vnet, cluster_subnet, connection_info, credentials, resource_group):
         if inherit_from_host:
             logging.info("Inheriting VNET/subnet from DSS host")
             self.vnet, self.subnet_id = get_host_network(credentials=credentials,
                                                          resource_group=resource_group,
                                                          connection_info=connection_info)
         else:
-            logging.info("Using custom VNET ({}) and subnet ({} for cluster".format(cluster_vnet, cluster_subnet))
+            logging.info("Using custom VNET ({}) and subnet ({}) for cluster".format(cluster_vnet, cluster_subnet))
             self.vnet = cluster_vnet
             self.subnet_id = get_subnet_id(resource_group=resource_group, connection_info=connection_info, vnet=cluster_vnet, subnet=cluster_subnet)
         return self

--- a/python-lib/dku_azure/utils.py
+++ b/python-lib/dku_azure/utils.py
@@ -40,7 +40,13 @@ def get_vm_resource_id(subscription_id=None,
 def get_subnet_id(connection_info, resource_group, vnet, subnet):
     """
     """
+    logging.info("Mapping subnet {} to its full resource ID...".format(subnet))
     subscription_id = connection_info.get("subscriptionId", None)
+    subnet_id = "/subscriptions/{}/resourceGroups/{}/providers/Microsoft.Network/virtualNetworks/{}/subnets/{}".format(subscription_id,
+                                                                                                                       resource_group,
+                                                                                                                       vnet,
+                                                                                                                       subnet)
+    logging.info("Subnet {} linked to the resource {}".format(subnet, subnet_id))
     return "/subscriptions/{}/resourceGroups/{}/providers/Microsoft.Network/virtualNetworks/{}/subnets/{}".format(subscription_id,
                                                                                                                   resource_group,
                                                                                                                   vnet,
@@ -49,13 +55,12 @@ def get_subnet_id(connection_info, resource_group, vnet, subnet):
 
 def get_host_network(credentials=None, resource_group=None, connection_info=None, api_version="2019-07-01"):
     """
-    F****d up way of doing simple things
+    Return the VNET and subnet id of the DSS host.
     """
     
-    logging.info("DEBUG Fetching DSS host network params...")
     logging.info("Getting instance metadata...")
     vm_name = get_instance_metadata()["compute"]["name"]
-    logging.info("DEBUG {}".format(vm_name))
+    logging.info("DSS host is on VNET {}".format(vm_name))
     subscription_id = connection_info.get("subscriptionId", None)
     vm_resource_id = get_vm_resource_id(subscription_id, resource_group, vm_name)
     resource_mgmt_client = ResourceManagementClient(credentials=credentials, subscription_id=subscription_id)

--- a/state.json
+++ b/state.json
@@ -1,7 +1,7 @@
 {
   "actions": [
     {
-      "ts": 1569314031519,
+      "ts": 1572355780924,
       "action": "INSTALL",
       "user": "admin"
     }


### PR DESCRIPTION
[ch43897]

* Issue reported by [ticket 13298](https://support.dataiku.com/a/tickets/13298). The fix was tested with:
  * "inherit from host" enabled
  * "inherit from host" disabled + cluster created in the same VNET but different subnet

* Add a "hidden" way to disable Azure GUID tag tracking by checking that a variable (need to set a variable env in `env-site.sh` to 1). Associated doc PR is available [here](https://github.com/dataiku/dss-doc/pull/273).