### PR TITLE
Add explicit versions for plugin code-env dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PLUGIN_VERSION=1.0.2
+PLUGIN_VERSION=1.0.3
 PLUGIN_ID=aks-clusters
 
 plugin:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ For more details, please see [the DSS reference documentation](https://doc.datai
 
 ## Release notes
 
+### v1.0.3
+
+- Minor fix on cluster autoscaler
+- Explicit definition of the code-env package versions
+
 ### v1.0.2
 
 - Minor fix on Azure API calls.

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -1,24 +1,6 @@
--i https://pypi.org/simple
-adal==1.2.4
 azure-common==1.1.25
 azure-mgmt-authorization==0.60.0
 azure-mgmt-compute==12.1.0
 azure-mgmt-containerservice==9.1.0
 azure-mgmt-resource==10.0.0
-certifi==2020.6.20
-cffi==1.14.0
-chardet==3.0.4
-cryptography==2.9.2
-idna==2.9
-isodate==0.6.0
-msrest==0.6.16
-msrestazure==0.6.3
-oauthlib==3.1.0
-pycparser==2.20
-pyjwt==1.7.1
-python-dateutil==2.8.1
 pyyaml==5.3.1
-requests-oauthlib==1.3.0
-requests==2.24.0
-six==1.15.0
-urllib3==1.25.9


### PR DESCRIPTION
To avoid using outdated client libs with Azure, package versions are explicitly mentioned in requirements.txt. 

As of today, it is a manual process: directly reusing the output of `pipenv lock` to generate a requirements.txt file would result in an error since it will generate a list of explicit package versions, including the dependencies, and it would conflict with the "base" DSS requirements for the code-env.