### PR TITLE
1.1.0 tentative improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PLUGIN_VERSION=1.0.3
+PLUGIN_VERSION=1.1.0dev
 PLUGIN_ID=aks-clusters
 
 plugin:

--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -1,5 +1,5 @@
 {
-  "acceptedPythonInterpreters": [],
+  "acceptedPythonInterpreters": ["PYTHON27", "PYTHON36"],
   "forceConda": false,
   "installCorePackages": true,
   "installJupyterSupport": false

--- a/parameter-sets/node-pool-request/parameter-set.json
+++ b/parameter-sets/node-pool-request/parameter-set.json
@@ -59,6 +59,39 @@
             "visibilityCondition": "model.autoScaling"
         },
         {
+            "name": "nodepoolLabels",
+            "label": "Node labels",
+            "type": "KEY_VALUE_LIST"
+        },
+        {
+            "name":  "nodepoolTags",
+            "label": "Tags",
+            "type": "KEY_VALUE_LIST"
+        },
+        {
+            "name": "applyNodeTaints",
+            "label": "Apply node taints",
+            "type": "BOOLEAN"
+        },
+        {
+            "name": "NoSchedule",
+            "label": "NoSchedule",
+            "type": "KEY_VALUE_LIST",
+            "visibilityCondition": "model.applyNodeTaints"
+        },
+        {
+            "name": "PreferNoSchedule",
+            "label": "PreferNoSchedule",
+            "type": "KEY_VALUE_LIST",
+            "visibilityCondition": "model.applyNodeTaints"
+        },
+        {
+            "name": "NoExecute",
+            "label": "NoExecute",
+            "type": "KEY_VALUE_LIST",
+            "visibilityCondition": "model.applyNodeTaints"
+        },
+        {
             "type": "SEPARATOR",
             "label": "Networking"
         },

--- a/parameter-sets/node-pool-request/parameter-set.json
+++ b/parameter-sets/node-pool-request/parameter-set.json
@@ -71,7 +71,8 @@
         {
             "name": "applyNodeTaints",
             "label": "Apply node taints",
-            "type": "BOOLEAN"
+            "type": "BOOLEAN",
+            "description": "WARNING: you need at least 1 untainted node pool!"
         },
         {
             "name": "NoSchedule",

--- a/plugin.json
+++ b/plugin.json
@@ -5,7 +5,7 @@
         "label": "AKS clusters",
         "description": "Interact with or create Microsoft Azure Kubernetes Service clusters",
         "author": "Dataiku",
-        "icon": "icon-azure-kubernetes-services-icon-cloud",
+        "icon": "icon-azure-kubernetes-services icon-cloud",
         "licenseInfo" : "Apache Software License",
         "url": "https://github.com/dataiku/dss-plugin-aks-clusters",
         "tags": ["Cloud", "Microsoft Azure"],

--- a/plugin.json
+++ b/plugin.json
@@ -5,7 +5,7 @@
         "label": "AKS clusters",
         "description": "Interact with or create Microsoft Azure Kubernetes Service clusters",
         "author": "Dataiku",
-        "icon": "icon-puzzle-piece",
+        "icon": "icon-azure-kubernetes-services-icon-cloud",
         "licenseInfo" : "Apache Software License",
         "url": "https://github.com/dataiku/dss-plugin-aks-clusters",
         "tags": ["Cloud", "Microsoft Azure"],

--- a/python-clusters/create-aks-cluster/cluster.py
+++ b/python-clusters/create-aks-cluster/cluster.py
@@ -100,6 +100,10 @@ class MyCluster(Cluster):
                                               max_num_nodes=node_pool_conf.get("maxNumNodes", None))
 
             node_pool_builder.with_disk_size_gb(disk_size_gb=node_pool_conf.get("osDiskSizeGb", 0))
+            node_pool_builder.with_nodepool_taints(nodepool_taints=node_pool_conf.get("nodepoolTaints", None))
+            node_pool_builder.with_nodepool_labels(nodepool_labels=node_pool_conf.get("nodepoolLabels", None))
+            node_pool_builder.with_nodepool_tags(nodepool_tags=node_pool_conf.get("nodepoolTags", None))
+            
             node_pool_builder.build()
             cluster_builder.with_node_pool(node_pool=node_pool_builder.agent_pool_profile)
         

--- a/python-clusters/create-aks-cluster/cluster.py
+++ b/python-clusters/create-aks-cluster/cluster.py
@@ -8,7 +8,7 @@ from azure.mgmt.containerservice.models import ManagedClusterAgentPoolProfile
 from azure.mgmt.containerservice.models import ContainerServiceVMSizeTypes
 from msrestazure.azure_exceptions import CloudError
 
-from dku_utils.access import _is_none_or_blank, _has_not_blank_property
+from dku_utils.access import _is_none_or_blank, _has_not_blank_property, collect_taints
 from dku_utils.cluster import make_overrides, get_cluster_from_connection_info
 from dku_azure.auth import get_credentials_from_connection_info
 from dku_azure.clusters import ClusterBuilder
@@ -100,10 +100,12 @@ class MyCluster(Cluster):
                                               max_num_nodes=node_pool_conf.get("maxNumNodes", None))
 
             node_pool_builder.with_disk_size_gb(disk_size_gb=node_pool_conf.get("osDiskSizeGb", 0))
-            node_pool_builder.with_nodepool_taints(nodepool_taints=node_pool_conf.get("nodepoolTaints", None))
             node_pool_builder.with_nodepool_labels(nodepool_labels=node_pool_conf.get("nodepoolLabels", None))
             node_pool_builder.with_nodepool_tags(nodepool_tags=node_pool_conf.get("nodepoolTags", None))
-            
+            #node_pool_builder.with_nodepool_taints(nodepool_taints=node_pool_conf.get("nodepoolTaints", None))
+            node_pool_builder.with_nodepool_taints(nodepool_taints=collect_taints(node_pool_conf))
+
+
             node_pool_builder.build()
             cluster_builder.with_node_pool(node_pool=node_pool_builder.agent_pool_profile)
         

--- a/python-lib/dku_azure/clusters.py
+++ b/python-lib/dku_azure/clusters.py
@@ -2,6 +2,7 @@ from dku_azure.utils import get_instance_metadata, get_vm_resource_id, get_host_
 from azure.mgmt.containerservice.models import ManagedClusterAgentPoolProfile
 from azure.mgmt.containerservice.models import ContainerServiceNetworkProfile, ContainerServiceServicePrincipalProfile, ManagedCluster
 from dku_utils.access import _default_if_blank
+from dku_utils.access import kvl_to_list, kvl_to_dict
 
 import logging
 
@@ -103,6 +104,9 @@ class NodePoolBuilder(object):
         self.idx = None
         self.agent_pool_profile = None
         self.gpu = None
+        self.nodepool_taints = None
+        self.nodepool_labels = None
+        self.nodepool_tags = None
 
 
     def with_name(self, name):
@@ -155,6 +159,23 @@ class NodePoolBuilder(object):
             self.disk_size_gb = disk_size_gb
         return self
 
+    def with_nodepool_taints(self, nodepool_taints):
+        #TODO
+        if nodepool_taints:
+            self.nodepool_taints = kvl_to_list(nodepool_taints)
+        return self
+
+    def with_nodepool_labels(self, nodepool_labels):
+        #TODO
+        if nodepool_labels:
+            self.nodepool_labels = kvl_to_dict(nodepool_labels)
+        return self
+
+    def with_nodepool_tags(self, nodepool_tags):
+        #TODO
+        if nodepool_tags:
+            self.nodepool_tags = kvl_to_dict(nodepool_tags)
+
     def build(self):
         agent_pool_profile_params = {}
         if self.idx == 0:
@@ -170,6 +191,12 @@ class NodePoolBuilder(object):
             agent_pool_profile_params["min_count"] = self.min_num_nodes
         if self.max_num_nodes:
             agent_pool_profile_params["max_count"] = self.max_num_nodes
+        if self.nodepool_taints:
+            agent_pool_profile_params["node_taints"] = self.nodepool_taints
+        if self.nodepool_labels:
+            agent_pool_profile_params["node_labels"] = self.nodepool_labels
+        if self.nodepool_tags:
+            agent_pool_profile_params["tags"] = self.nodepool_tags
 
         logging.info("Adding agent pool profile: %s" % agent_pool_profile_params)
 

--- a/python-lib/dku_azure/clusters.py
+++ b/python-lib/dku_azure/clusters.py
@@ -160,19 +160,16 @@ class NodePoolBuilder(object):
         return self
 
     def with_nodepool_taints(self, nodepool_taints):
-        #TODO
         if nodepool_taints:
-            self.nodepool_taints = kvl_to_list(nodepool_taints)
+            self.nodepool_taints = nodepool_taints
         return self
 
     def with_nodepool_labels(self, nodepool_labels):
-        #TODO
         if nodepool_labels:
             self.nodepool_labels = kvl_to_dict(nodepool_labels)
         return self
 
     def with_nodepool_tags(self, nodepool_tags):
-        #TODO
         if nodepool_tags:
             self.nodepool_tags = kvl_to_dict(nodepool_tags)
 

--- a/python-lib/dku_azure/utils.py
+++ b/python-lib/dku_azure/utils.py
@@ -14,7 +14,7 @@ def run_and_process_cloud_error(fn):
     except CloudError as e:
         raise Exception('%s : %s' % (e.error, e.response.content))
     except Exception as e:
-        raise e.decode('utf-8')
+        raise e.message.decode('utf-8')
         
 
 def get_instance_metadata(api_version="2019-04-30"):

--- a/python-lib/dku_azure/utils.py
+++ b/python-lib/dku_azure/utils.py
@@ -12,9 +12,9 @@ def run_and_process_cloud_error(fn):
     try:
         return fn()
     except CloudError as e:
-        raise Exception('%s : %s' % (str(e), e.response.content))
+        raise Exception('%s : %s' % (e.error, e.response.content))
     except Exception as e:
-        raise e
+        raise e.decode('utf-8')
         
 
 def get_instance_metadata(api_version="2019-04-30"):

--- a/python-lib/dku_azure/utils.py
+++ b/python-lib/dku_azure/utils.py
@@ -14,7 +14,7 @@ def run_and_process_cloud_error(fn):
     except CloudError as e:
         raise Exception('%s : %s' % (e.error, e.response.content))
     except Exception as e:
-        raise e.message.decode('utf-8')
+        raise e
         
 
 def get_instance_metadata(api_version="2019-04-30"):

--- a/python-lib/dku_utils/access.py
+++ b/python-lib/dku_utils/access.py
@@ -1,4 +1,5 @@
 from collections import Mapping, Iterable
+from six import text_type
 
 def _get_in_object_or_array(o, chunk, d):
     if isinstance(chunk, int):
@@ -16,7 +17,7 @@ def _safe_get_value(o, chunks, default_value=None):
         return _safe_get_value(_get_in_object_or_array(o, chunks[0], {}), chunks[1:], default_value)
 
 def _is_none_or_blank(x):
-    return x is None or (isinstance(x, str) and len(x.strip()) == 0) or(isinstance(x, unicode) and len(x.strip()) == 0)
+    return x is None or (isinstance(x, text_type) and len(x.strip()) == 0)
 
 def _has_not_blank_property(d, k):
     return k in d and not _is_none_or_blank(d[k])
@@ -57,4 +58,13 @@ def _merge_objects(a, b):
     else:
         return a
     
-    
+def kvl_to_dict(kvl):
+    d = {l["from"]: l["to"] for l in kvl}
+    return d
+
+def kvl_to_list(kvl):
+    d = kvl_to_dict(kvl)
+    output = ["{}={}".format(k, d[k]) for k in d]
+    print("DEBUG")
+    print(output)
+    return output

--- a/python-lib/dku_utils/access.py
+++ b/python-lib/dku_utils/access.py
@@ -59,12 +59,25 @@ def _merge_objects(a, b):
         return a
     
 def kvl_to_dict(kvl):
-    d = {l["from"]: l["to"] for l in kvl}
-    return d
+    if kvl:
+        d = {l["from"]: l["to"] for l in kvl}
+        return d
+    else:
+        return None
 
 def kvl_to_list(kvl):
     d = kvl_to_dict(kvl)
-    output = ["{}={}".format(k, d[k]) for k in d]
-    print("DEBUG")
-    print(output)
-    return output
+    if d:
+        output = ["{}={}".format(k, d[k]) for k in d]
+        return output
+    else:
+        return None
+
+def collect_taints(node_pool_conf):
+    taints_list = []
+    if node_pool_conf.get("applyNodeTaints"):
+        for effect in ["NoSchedule", "PreferNoSchedule", "NoExecute"]:
+            taints_dict = kvl_to_dict(node_pool_conf.get(effect, None))
+            if taints_dict:
+                taints_list += ["{}={}:{}".format(k, taints_dict[k], effect ) for k in taints_dict]
+    return taints_list


### PR DESCRIPTION
- [x] Better handling of encoding errors when dealing with stuff like [this](https://github.com/Azure/azure-cli/issues/12207). Should be fixed in `msrestazure==0.6.4`, best way is to check with a classic "exhausted-quota" error :trollface: 
- [x] Add taints on a nodepool (parameter-set)
- [ ] Create new nodepool with taints (runnable)
- [x] New icon (issue #6 )
- [ ] Advanced: custom yaml/json-based configuration (similar to GKE and EKS plugins)
- [ ] Advanced: custom name for nodeResourceGroup (issue #9 )
- [ ] Explicit naming for additional nodepools (runnable)