### PR TITLE
AKS Private Cluster and Custom User Defined Routing

### DIFF
--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -1,6 +1,6 @@
 azure-common==1.1.25
 azure-mgmt-authorization==0.60.0
 azure-mgmt-compute==12.1.0
-azure-mgmt-containerservice==9.1.0
+azure-mgmt-containerservice==9.2.0
 azure-mgmt-resource==10.0.0
 pyyaml==5.3.1

--- a/parameter-sets/connection-info/parameter-set.json
+++ b/parameter-sets/connection-info/parameter-set.json
@@ -36,6 +36,12 @@
             "label": "Password",
             "type": "PASSWORD",
             "mandatory" : true
+        },
+        {
+            "name": "privateAccess",
+            "label": "Private Cluster",
+            "type": "BOOLEAN",
+            "defaultValue": false
         }
     ]
 }

--- a/parameter-sets/connection-info/parameter-set.json
+++ b/parameter-sets/connection-info/parameter-set.json
@@ -48,10 +48,10 @@
             "label": "Cluster Egress Type",
             "type": "SELECT",
             "selectChoices": [
-                { "value": "slb", "label": "loadBalancer"},
-                { "value": "udr", "label": "userDefinedRouting"}
+                { "value": "loadBalancer", "label": "loadBalancer"},
+                { "value": "userDefinedRouting", "label": "userDefinedRouting"}
             ],
-            "defaultValue": "udr"
+            "defaultValue": "userDefinedRouting"
         }
     ]
 }

--- a/parameter-sets/connection-info/parameter-set.json
+++ b/parameter-sets/connection-info/parameter-set.json
@@ -42,6 +42,16 @@
             "label": "Private Cluster",
             "type": "BOOLEAN",
             "defaultValue": false
+        },
+        {
+            "name": "clusterEgress",
+            "label": "Cluster Egress Type",
+            "type": "SELECT",
+            "selectChoices": [
+                { "value": "slb", "label": "loadBalancer"},
+                { "value": "udr", "label": "userDefinedRouting"}
+            ],
+            "defaultValue": "udr"
         }
     ]
 }

--- a/parameter-sets/connection-info/parameter-set.json
+++ b/parameter-sets/connection-info/parameter-set.json
@@ -36,12 +36,6 @@
             "label": "Password",
             "type": "PASSWORD",
             "mandatory" : true
-        },
-        {
-            "name": "privateAccess",
-            "label": "Private Cluster",
-            "type": "BOOLEAN",
-            "defaultValue": false
         }
     ]
 }

--- a/parameter-sets/connection-info/parameter-set.json
+++ b/parameter-sets/connection-info/parameter-set.json
@@ -42,16 +42,6 @@
             "label": "Private Cluster",
             "type": "BOOLEAN",
             "defaultValue": false
-        },
-        {
-            "name": "clusterEgress",
-            "label": "Cluster Egress Type",
-            "type": "SELECT",
-            "selectChoices": [
-                { "value": "loadBalancer", "label": "loadBalancer"},
-                { "value": "userDefinedRouting", "label": "userDefinedRouting"}
-            ],
-            "defaultValue": "userDefinedRouting"
         }
     ]
 }

--- a/python-clusters/create-aks-cluster/cluster.json
+++ b/python-clusters/create-aks-cluster/cluster.json
@@ -101,6 +101,13 @@
             "mandatory": true
         },
         {
+            "name": "dockerBridgeCidr",
+            "label": "Docker Bridge CIDR",
+            "description": "A CIDR notation IP range assigned to the Docker bridge network. It must not overlap with any Subnet IP ranges or the Kubernetes service address range.",
+            "type": "STRING",
+            "defaultValue": "172.17.0.1/16"
+        },
+        {
             "name": "outboundType",
             "label": "Outbound Type",
             "description": "https://docs.microsoft.com/en-us/azure/aks/egress-outboundtype",

--- a/python-clusters/create-aks-cluster/cluster.json
+++ b/python-clusters/create-aks-cluster/cluster.json
@@ -71,9 +71,20 @@
         {
             "name": "privateAccess",
             "label": "Private Cluster Endpoint",
-            "description": "Cluster endpoint accessible through Private Link. If used, must set Load balancer SKU to Standard.",
+            "description": "Cluster endpoint accessible through Private Link. If used, must set Load balancer SKU to Standard",
             "type": "BOOLEAN",
             "defaultValue": false
+        },
+        {
+            "name": "networkPlugin",
+            "label": "Kubernetes Network Plugin",
+            "description": "Network plugin used for building Kubernetes network",
+            "type": "SELECT",
+            "selectChoices": [
+                {"value": "azure", "label": "Azure CNI"},
+                {"value": "kubenet", "label": "kubenet"}
+            ],
+            "defaultValue": "kubenet"
         },
         {
             "name": "serviceCIDR",

--- a/python-clusters/create-aks-cluster/cluster.json
+++ b/python-clusters/create-aks-cluster/cluster.json
@@ -103,7 +103,7 @@
             ],
             "mandatory": false,
             "defaultValue": "Basic",
-            "visibilityCondition": "model.networkProfileType == loadBalancer"
+            "visibilityCondition": "model.networkProfileType != loadBalancer"
         }
 
     ]

--- a/python-clusters/create-aks-cluster/cluster.json
+++ b/python-clusters/create-aks-cluster/cluster.json
@@ -103,7 +103,7 @@
             ],
             "mandatory": false,
             "defaultValue": "Basic",
-            "visibilityCondition": "model.networkProfileType != loadBalancer"
+            "visibilityCondition": "model.networkProfileType == 'loadBalancer'"
         }
 
     ]

--- a/python-clusters/create-aks-cluster/cluster.json
+++ b/python-clusters/create-aks-cluster/cluster.json
@@ -103,7 +103,7 @@
             ],
             "mandatory": false,
             "defaultValue": "Basic",
-            "visibilityCondition": "model.networkProfileType == 'loadBalancer'"
+            "visibilityCondition": "model.outboundType == 'loadBalancer'"
         }
 
     ]

--- a/python-clusters/create-aks-cluster/cluster.json
+++ b/python-clusters/create-aks-cluster/cluster.json
@@ -102,8 +102,7 @@
                 {"value":"Standard", "label":"Standard"}
             ],
             "mandatory": false,
-            "defaultValue": "Basic",
-            "visibilityCondition": "model.outboundType == 'loadBalancer'"
+            "defaultValue": "Basic"
         }
 
     ]

--- a/python-clusters/create-aks-cluster/cluster.json
+++ b/python-clusters/create-aks-cluster/cluster.json
@@ -83,6 +83,17 @@
             "mandatory": true
         },
         {
+            "name": "networkProfileType",
+            "label": "Network Profile",
+            "description": "https://docs.microsoft.com/en-us/azure/aks/egress-outboundtype",
+            "type": "SELECT",
+            "selectChoices": [
+                {"value": "userDefinedRouting", "label": "userDefinedRouting"},
+                {"value": "loadBalancer", "label": "loadBalancer"}
+            ],
+            "defaultValue": "loadBalancer"
+        }
+        {
             "name": "loadBalancerSku",
             "label": "Load balancer SKU",
             "type": "SELECT",
@@ -91,7 +102,8 @@
                 {"value":"Standard", "label":"Standard"}
             ],
             "mandatory": false,
-            "defaultValue": "Basic"
+            "defaultValue": "Basic",
+            "visibilityCondition": "model.networkProfileType == loadBalancer"
         }
 
     ]

--- a/python-clusters/create-aks-cluster/cluster.json
+++ b/python-clusters/create-aks-cluster/cluster.json
@@ -70,7 +70,8 @@
         },
         {
             "name": "privateAccess",
-            "label": "Private Cluster",
+            "label": "Private Cluster Endpoint",
+            "description": "Cluster endpoint accessible through Private Link. If used, must set Load balancer SKU to Standard.",
             "type": "BOOLEAN",
             "defaultValue": false
         },

--- a/python-clusters/create-aks-cluster/cluster.json
+++ b/python-clusters/create-aks-cluster/cluster.json
@@ -69,6 +69,12 @@
             "label": "Advanced options"
         },
         {
+            "name": "privateAccess",
+            "label": "Private Cluster",
+            "type": "BOOLEAN",
+            "defaultValue": false
+        },
+        {
             "name": "serviceCIDR",
             "label": "Service CIDR",
             "description": "IP range for services in the cluster (cannot overlap the IP range of the pools' subnets)",

--- a/python-clusters/create-aks-cluster/cluster.json
+++ b/python-clusters/create-aks-cluster/cluster.json
@@ -83,8 +83,8 @@
             "mandatory": true
         },
         {
-            "name": "networkProfileType",
-            "label": "Network Profile",
+            "name": "outboundType",
+            "label": "Outbound Type",
             "description": "https://docs.microsoft.com/en-us/azure/aks/egress-outboundtype",
             "type": "SELECT",
             "selectChoices": [

--- a/python-clusters/create-aks-cluster/cluster.json
+++ b/python-clusters/create-aks-cluster/cluster.json
@@ -92,7 +92,7 @@
                 {"value": "loadBalancer", "label": "loadBalancer"}
             ],
             "defaultValue": "loadBalancer"
-        }
+        },
         {
             "name": "loadBalancerSku",
             "label": "Load balancer SKU",

--- a/python-clusters/create-aks-cluster/cluster.py
+++ b/python-clusters/create-aks-cluster/cluster.py
@@ -75,6 +75,7 @@ class MyCluster(Cluster):
                                              dns_service_ip=self.config.get("dnsServiceIP", None),
                                              load_balancer_sku=self.config.get("loadBalancerSku", None))
         else:
+            print()
             cluster_builder.with_network_profile(service_cidr=self.config.get("serviceCIDR", None),
                                              dns_service_ip=self.config.get("dnsServiceIP", None),
                                              load_balancer_profile=self.config.get("networkProfileType", None))

--- a/python-clusters/create-aks-cluster/cluster.py
+++ b/python-clusters/create-aks-cluster/cluster.py
@@ -81,6 +81,9 @@ class MyCluster(Cluster):
 
         if connection_info.get("privateAccess"):
             cluster_builder.with_private_access(connection_info.get("privateAccess"))
+            
+        if connection_info.get("clusterEgress") == "userDefinedRouting":
+            cluster_builder.with_user_defined_route(connection_info.get("clusterEgress"))
 
         cluster_builder.with_cluster_version(self.config.get("clusterVersion", None))
         

--- a/python-clusters/create-aks-cluster/cluster.py
+++ b/python-clusters/create-aks-cluster/cluster.py
@@ -2,7 +2,7 @@ import os, json, logging, yaml, time
 from dataiku.cluster import Cluster
 
 from azure.mgmt.containerservice import ContainerServiceClient
-from azure.mgmt.containerservice.models import ManagedCluster, ManagedClusterServicePrincipalProfile, ManagedClusterAPIServerAccessProfile
+from azure.mgmt.containerservice.models import ManagedCluster, ManagedClusterServicePrincipalProfile
 from azure.mgmt.containerservice.models import ContainerServiceLinuxProfile, ContainerServiceNetworkProfile, ContainerServiceServicePrincipalProfile
 from azure.mgmt.containerservice.models import ManagedClusterAgentPoolProfile
 from azure.mgmt.containerservice.models import ContainerServiceVMSizeTypes

--- a/python-clusters/create-aks-cluster/cluster.py
+++ b/python-clusters/create-aks-cluster/cluster.py
@@ -75,9 +75,9 @@ class MyCluster(Cluster):
                                              dns_service_ip=self.config.get("dnsServiceIP", None),
                                              load_balancer_sku=self.config.get("loadBalancerSku", None))
         else:
-            cluster_builder.with_network_profile(service_cidr=self.config.get("serviceCIDR", None),
+            cluster_builder.with_network_profile(**{service_cidr=self.config.get("serviceCIDR", None),
                                              dns_service_ip=self.config.get("dnsServiceIP", None),
-                                             load_balancer_profile=self.config.get("networkProfileType", None))
+                                             load_balancer_profile=self.config.get("networkProfileType", None)})
 
         if self.config.get("useDistinctSPForCluster", False):
             cluster_sp = self.config.get("clusterServicePrincipal")

--- a/python-clusters/create-aks-cluster/cluster.py
+++ b/python-clusters/create-aks-cluster/cluster.py
@@ -69,9 +69,15 @@ class MyCluster(Cluster):
         cluster_builder.with_resource_group(resource_group)
         cluster_builder.with_location(self.config.get("location", None))
         cluster_builder.with_linux_profile() # default is None
-        cluster_builder.with_network_profile(service_cidr=self.config.get("serviceCIDR", None),
+        
+        if self.config.get("networkProfileType") == "loadBalancer":
+            cluster_builder.with_network_profile(service_cidr=self.config.get("serviceCIDR", None),
                                              dns_service_ip=self.config.get("dnsServiceIP", None),
                                              load_balancer_sku=self.config.get("loadBalancerSku", None))
+        else:
+            cluster_builder.with_network_profile(service_cidr=self.config.get("serviceCIDR", None),
+                                             dns_service_ip=self.config.get("dnsServiceIP", None),
+                                             load_balancer_profile=self.config.get("networkProfileType", None))
 
         if self.config.get("useDistinctSPForCluster", False):
             cluster_sp = self.config.get("clusterServicePrincipal")
@@ -81,9 +87,6 @@ class MyCluster(Cluster):
 
         if connection_info.get("privateAccess"):
             cluster_builder.with_private_access(connection_info.get("privateAccess"))
-            
-        if connection_info.get("clusterEgress") == "userDefinedRouting":
-            cluster_builder.with_user_defined_route(connection_info.get("clusterEgress"))
 
         cluster_builder.with_cluster_version(self.config.get("clusterVersion", None))
         

--- a/python-clusters/create-aks-cluster/cluster.py
+++ b/python-clusters/create-aks-cluster/cluster.py
@@ -75,9 +75,9 @@ class MyCluster(Cluster):
                                              dns_service_ip=self.config.get("dnsServiceIP", None),
                                              load_balancer_sku=self.config.get("loadBalancerSku", None))
         else:
-            cluster_builder.with_network_profile(**{service_cidr=self.config.get("serviceCIDR", None),
+            cluster_builder.with_network_profile(service_cidr=self.config.get("serviceCIDR", None),
                                              dns_service_ip=self.config.get("dnsServiceIP", None),
-                                             load_balancer_profile=self.config.get("networkProfileType", None)})
+                                             load_balancer_profile=self.config.get("networkProfileType", None))
 
         if self.config.get("useDistinctSPForCluster", False):
             cluster_sp = self.config.get("clusterServicePrincipal")

--- a/python-clusters/create-aks-cluster/cluster.py
+++ b/python-clusters/create-aks-cluster/cluster.py
@@ -80,7 +80,7 @@ class MyCluster(Cluster):
         cluster_builder.with_cluster_sp(cluster_service_principal_connection_info=cluster_sp)
 
         if connection_info.get("privateAccess"):
-            cluster_builder.with_private_access(self.connection_info.get("privateAccess"))
+            cluster_builder.with_private_access(connection_info.get("privateAccess"))
 
         cluster_builder.with_cluster_version(self.config.get("clusterVersion", None))
         

--- a/python-clusters/create-aks-cluster/cluster.py
+++ b/python-clusters/create-aks-cluster/cluster.py
@@ -79,7 +79,7 @@ class MyCluster(Cluster):
             cluster_sp = connection_info
         cluster_builder.with_cluster_sp(cluster_service_principal_connection_info=cluster_sp)
 
-        if self.connection_info.get("privateAccess"):
+        if connection_info.get("privateAccess"):
             cluster_builder.with_private_access(self.connection_info.get("privateAccess"))
 
         cluster_builder.with_cluster_version(self.config.get("clusterVersion", None))

--- a/python-clusters/create-aks-cluster/cluster.py
+++ b/python-clusters/create-aks-cluster/cluster.py
@@ -69,16 +69,10 @@ class MyCluster(Cluster):
         cluster_builder.with_resource_group(resource_group)
         cluster_builder.with_location(self.config.get("location", None))
         cluster_builder.with_linux_profile() # default is None
-        
-        if self.config.get("outboundType") == "loadBalancer":
-            cluster_builder.with_network_profile(service_cidr=self.config.get("serviceCIDR", None),
-                                             dns_service_ip=self.config.get("dnsServiceIP", None),
-                                             load_balancer_sku=self.config.get("loadBalancerSku", None))
-        else:
-            cluster_builder.with_network_profile(service_cidr=self.config.get("serviceCIDR", None),
-                                             dns_service_ip=self.config.get("dnsServiceIP", None),
-                                             load_balancer_sku=self.config.get("loadBalancerSku", None),
-                                             outbound_type=self.config.get("outboundType", None))
+        cluster_builder.with_network_profile(service_cidr=self.config.get("serviceCIDR", None),
+                                         dns_service_ip=self.config.get("dnsServiceIP", None),
+                                         load_balancer_sku=self.config.get("loadBalancerSku", None),
+                                         outbound_type=self.config.get("outboundType", None))
 
         if self.config.get("useDistinctSPForCluster", False):
             cluster_sp = self.config.get("clusterServicePrincipal")
@@ -86,7 +80,7 @@ class MyCluster(Cluster):
             cluster_sp = connection_info
         cluster_builder.with_cluster_sp(cluster_service_principal_connection_info=cluster_sp)
 
-        if connection_info.get("privateAccess"):
+        if self.config.get("privateAccess"):
             cluster_builder.with_private_access(connection_info.get("privateAccess"))
 
         cluster_builder.with_cluster_version(self.config.get("clusterVersion", None))

--- a/python-clusters/create-aks-cluster/cluster.py
+++ b/python-clusters/create-aks-cluster/cluster.py
@@ -70,7 +70,7 @@ class MyCluster(Cluster):
         cluster_builder.with_location(self.config.get("location", None))
         cluster_builder.with_linux_profile() # default is None
         
-        if self.config.get("networkProfileType") == "loadBalancer":
+        if self.config.get("outboundType") == "loadBalancer":
             cluster_builder.with_network_profile(service_cidr=self.config.get("serviceCIDR", None),
                                              dns_service_ip=self.config.get("dnsServiceIP", None),
                                              load_balancer_sku=self.config.get("loadBalancerSku", None))
@@ -78,7 +78,7 @@ class MyCluster(Cluster):
             print()
             cluster_builder.with_network_profile(service_cidr=self.config.get("serviceCIDR", None),
                                              dns_service_ip=self.config.get("dnsServiceIP", None),
-                                             load_balancer_profile=self.config.get("networkProfileType", None))
+                                             outbound_type=self.config.get("outboundType", None))
 
         if self.config.get("useDistinctSPForCluster", False):
             cluster_sp = self.config.get("clusterServicePrincipal")

--- a/python-clusters/create-aks-cluster/cluster.py
+++ b/python-clusters/create-aks-cluster/cluster.py
@@ -73,7 +73,8 @@ class MyCluster(Cluster):
                                          dns_service_ip=self.config.get("dnsServiceIP", None),
                                          load_balancer_sku=self.config.get("loadBalancerSku", None),
                                          outbound_type=self.config.get("outboundType", None),
-                                         network_plugin=self.config.get("networkPlugin"))
+                                         network_plugin=self.config.get("networkPlugin"),
+                                         docker_bridge_cidr=self.config.get("dockerBridgeCidr"))
 
         if self.config.get("useDistinctSPForCluster", False):
             cluster_sp = self.config.get("clusterServicePrincipal")

--- a/python-clusters/create-aks-cluster/cluster.py
+++ b/python-clusters/create-aks-cluster/cluster.py
@@ -72,7 +72,8 @@ class MyCluster(Cluster):
         cluster_builder.with_network_profile(service_cidr=self.config.get("serviceCIDR", None),
                                          dns_service_ip=self.config.get("dnsServiceIP", None),
                                          load_balancer_sku=self.config.get("loadBalancerSku", None),
-                                         outbound_type=self.config.get("outboundType", None))
+                                         outbound_type=self.config.get("outboundType", None),
+                                         network_plugin=self.config.get("networkPlugin"))
 
         if self.config.get("useDistinctSPForCluster", False):
             cluster_sp = self.config.get("clusterServicePrincipal")

--- a/python-clusters/create-aks-cluster/cluster.py
+++ b/python-clusters/create-aks-cluster/cluster.py
@@ -75,7 +75,6 @@ class MyCluster(Cluster):
                                              dns_service_ip=self.config.get("dnsServiceIP", None),
                                              load_balancer_sku=self.config.get("loadBalancerSku", None))
         else:
-            print()
             cluster_builder.with_network_profile(service_cidr=self.config.get("serviceCIDR", None),
                                              dns_service_ip=self.config.get("dnsServiceIP", None),
                                              outbound_type=self.config.get("outboundType", None))

--- a/python-clusters/create-aks-cluster/cluster.py
+++ b/python-clusters/create-aks-cluster/cluster.py
@@ -82,7 +82,7 @@ class MyCluster(Cluster):
         cluster_builder.with_cluster_sp(cluster_service_principal_connection_info=cluster_sp)
 
         if self.config.get("privateAccess"):
-            cluster_builder.with_private_access(connection_info.get("privateAccess"))
+            cluster_builder.with_private_access(self.config.get("privateAccess"))
 
         cluster_builder.with_cluster_version(self.config.get("clusterVersion", None))
         

--- a/python-clusters/create-aks-cluster/cluster.py
+++ b/python-clusters/create-aks-cluster/cluster.py
@@ -2,7 +2,7 @@ import os, json, logging, yaml, time
 from dataiku.cluster import Cluster
 
 from azure.mgmt.containerservice import ContainerServiceClient
-from azure.mgmt.containerservice.models import ManagedCluster, ManagedClusterServicePrincipalProfile
+from azure.mgmt.containerservice.models import ManagedCluster, ManagedClusterServicePrincipalProfile, ManagedClusterAPIServerAccessProfile
 from azure.mgmt.containerservice.models import ContainerServiceLinuxProfile, ContainerServiceNetworkProfile, ContainerServiceServicePrincipalProfile
 from azure.mgmt.containerservice.models import ManagedClusterAgentPoolProfile
 from azure.mgmt.containerservice.models import ContainerServiceVMSizeTypes
@@ -78,6 +78,9 @@ class MyCluster(Cluster):
         else:
             cluster_sp = connection_info
         cluster_builder.with_cluster_sp(cluster_service_principal_connection_info=cluster_sp)
+
+        if self.connection_info.get("privateAccess"):
+            cluster_builder.with_private_access(self.connection_info.get("privateAccess"))
 
         cluster_builder.with_cluster_version(self.config.get("clusterVersion", None))
         

--- a/python-clusters/create-aks-cluster/cluster.py
+++ b/python-clusters/create-aks-cluster/cluster.py
@@ -77,6 +77,7 @@ class MyCluster(Cluster):
         else:
             cluster_builder.with_network_profile(service_cidr=self.config.get("serviceCIDR", None),
                                              dns_service_ip=self.config.get("dnsServiceIP", None),
+                                             load_balancer_sku=self.config.get("loadBalancerSku", None),
                                              outbound_type=self.config.get("outboundType", None))
 
         if self.config.get("useDistinctSPForCluster", False):

--- a/python-lib/dku_azure/clusters.py
+++ b/python-lib/dku_azure/clusters.py
@@ -101,7 +101,8 @@ class ClusterBuilder(object):
         if self.private_access:
             cluster_params["api_server_access_profile"] = self.private_access
             
-
+        
+        print(cluster_params)
         self.cluster_config = ManagedCluster(**cluster_params)
         return self.clusters_client.managed_clusters.create_or_update(self.resource_group, self.name, self.cluster_config)
 

--- a/python-lib/dku_azure/clusters.py
+++ b/python-lib/dku_azure/clusters.py
@@ -44,8 +44,19 @@ class ClusterBuilder(object):
         self.linux_profile = linux_profile
         return self
 
-    def with_network_profile(self, **kwargs):
-        self.network_profile = ContainerServiceNetworkProfile(**kwargs)
+    def with_network_profile(self, service_cidr, dns_service_ip, load_balancer_sku=None, load_balancer_profile=None):
+        if load_balancer_sku:
+            self.network_profile = ContainerServiceNetworkProfile(
+                service_cidr = service_cidr,
+                dns_service_ip = dns_service_ip,
+                load_balancer_sku = load_balancer_sku
+            )
+        else:
+            self.network_profile = ContainerServiceNetworkProfile(
+                service_cidr = service_cidr,
+                dns_service_ip = dns_service_ip,
+                load_balancer_profile = load_balancer_profile
+            )
         return self
 
     def with_cluster_sp(self, cluster_service_principal_connection_info):

--- a/python-lib/dku_azure/clusters.py
+++ b/python-lib/dku_azure/clusters.py
@@ -53,8 +53,8 @@ class ClusterBuilder(object):
             )
         else:
             self.network_profile = ContainerServiceNetworkProfile(
-#                 service_cidr = service_cidr,
-#                 dns_service_ip = dns_service_ip,
+                service_cidr = service_cidr,
+                dns_service_ip = dns_service_ip,
                 outbound_type = outbound_type
             )
         return self

--- a/python-lib/dku_azure/clusters.py
+++ b/python-lib/dku_azure/clusters.py
@@ -22,6 +22,7 @@ class ClusterBuilder(object):
         self.node_pools = []
         self.cluster_version = None
         self.private_access = None
+        self.load_balancer_profile = None
 
 
     def with_name(self, name):
@@ -62,6 +63,12 @@ class ClusterBuilder(object):
             enable_private_cluster=private_access
         )
         return self
+    
+    def with_user_defined_route(self, load_balancer_profile):
+        self.load_balancer_profile = ContainerServiceNetworkProfile(
+            load_balancer_profile = load_balancer_profile
+        )
+        return self
 
     def get_node_pool_builder(self):
         nb_node_pools = len(self.node_pools)
@@ -89,6 +96,9 @@ class ClusterBuilder(object):
 
         if self.private_access:
             cluster_params["api_server_access_profile"] = self.private_access
+            
+        if self.load_balancer_profile:
+            cluster_params["network_profile"] = self.load_balancer_profile
 
         self.cluster_config = ManagedCluster(**cluster_params)
         return self.clusters_client.managed_clusters.create_or_update(self.resource_group, self.name, self.cluster_config)

--- a/python-lib/dku_azure/clusters.py
+++ b/python-lib/dku_azure/clusters.py
@@ -45,8 +45,8 @@ class ClusterBuilder(object):
         self.linux_profile = linux_profile
         return self
 
-    def with_network_profile(self, service_cidr, dns_service_ip, load_balancer_sku):
-        self.network_profile = ContainerServiceNetworkProfile(service_cidr=service_cidr, dns_service_ip=dns_service_ip, load_balancer_sku=load_balancer_sku)
+    def with_network_profile(self, **kwargs):
+        self.network_profile = ContainerServiceNetworkProfile(**kwargs)
         return self
 
     def with_cluster_sp(self, cluster_service_principal_connection_info):

--- a/python-lib/dku_azure/clusters.py
+++ b/python-lib/dku_azure/clusters.py
@@ -57,7 +57,7 @@ class ClusterBuilder(object):
                 dns_service_ip = dns_service_ip,
                 load_balancer_profile = load_balancer_profile
             )
-            print(ContainerServiceNetworkProfile.load_balancer_profile)
+            print(self.network_profile.load_balancer_profile)
         return self
 
     def with_cluster_sp(self, cluster_service_principal_connection_info):

--- a/python-lib/dku_azure/clusters.py
+++ b/python-lib/dku_azure/clusters.py
@@ -44,25 +44,13 @@ class ClusterBuilder(object):
         self.linux_profile = linux_profile
         return self
 
-    def with_network_profile(self, service_cidr, dns_service_ip, load_balancer_sku=None, outbound_type=None):
+    def with_network_profile(self, service_cidr, dns_service_ip, load_balancer_sku, outbound_type):
         self.network_profile = ContainerServiceNetworkProfile(
             service_cidr = service_cidr,
             dns_service_ip = dns_service_ip,
             load_balancer_sku = load_balancer_sku,
             outbound_type = outbound_type
         )
-#         if load_balancer_sku:
-#             self.network_profile = ContainerServiceNetworkProfile(
-#                 service_cidr = service_cidr,
-#                 dns_service_ip = dns_service_ip,
-#                 load_balancer_sku = load_balancer_sku
-#             )
-#         else:
-#             self.network_profile = ContainerServiceNetworkProfile(
-#                 service_cidr = service_cidr,
-#                 dns_service_ip = dns_service_ip,
-#                 outbound_type = outbound_type
-#             )
         return self
 
     def with_cluster_sp(self, cluster_service_principal_connection_info):

--- a/python-lib/dku_azure/clusters.py
+++ b/python-lib/dku_azure/clusters.py
@@ -53,8 +53,8 @@ class ClusterBuilder(object):
             )
         else:
             self.network_profile = ContainerServiceNetworkProfile(
-                service_cidr = service_cidr,
-                dns_service_ip = dns_service_ip,
+#                 service_cidr = service_cidr,
+#                 dns_service_ip = dns_service_ip,
                 outbound_type = outbound_type
             )
         return self

--- a/python-lib/dku_azure/clusters.py
+++ b/python-lib/dku_azure/clusters.py
@@ -22,7 +22,6 @@ class ClusterBuilder(object):
         self.node_pools = []
         self.cluster_version = None
         self.private_access = None
-        self.load_balancer_profile = None
 
 
     def with_name(self, name):
@@ -61,12 +60,6 @@ class ClusterBuilder(object):
     def with_private_access(self, private_access):
         self.private_access = ManagedClusterAPIServerAccessProfile(
             enable_private_cluster=private_access
-        )
-        return self
-    
-    def with_user_defined_route(self, load_balancer_profile):
-        self.load_balancer_profile = ContainerServiceNetworkProfile(
-            load_balancer_profile = load_balancer_profile
         )
         return self
 

--- a/python-lib/dku_azure/clusters.py
+++ b/python-lib/dku_azure/clusters.py
@@ -44,13 +44,14 @@ class ClusterBuilder(object):
         self.linux_profile = linux_profile
         return self
 
-    def with_network_profile(self, service_cidr, dns_service_ip, load_balancer_sku, outbound_type, network_plugin):
+    def with_network_profile(self, service_cidr, dns_service_ip, load_balancer_sku, outbound_type, network_plugin, docker_bridge_cidr):
         self.network_profile = ContainerServiceNetworkProfile(
             service_cidr = service_cidr,
             dns_service_ip = dns_service_ip,
             load_balancer_sku = load_balancer_sku,
             outbound_type = outbound_type,
-            network_plugin = network_plugin
+            network_plugin = network_plugin,
+            docker_bridge_cidr = docker_bridge_cidr
         )
         return self
 

--- a/python-lib/dku_azure/clusters.py
+++ b/python-lib/dku_azure/clusters.py
@@ -44,12 +44,13 @@ class ClusterBuilder(object):
         self.linux_profile = linux_profile
         return self
 
-    def with_network_profile(self, service_cidr, dns_service_ip, load_balancer_sku, outbound_type):
+    def with_network_profile(self, service_cidr, dns_service_ip, load_balancer_sku, outbound_type, network_plugin):
         self.network_profile = ContainerServiceNetworkProfile(
             service_cidr = service_cidr,
             dns_service_ip = dns_service_ip,
             load_balancer_sku = load_balancer_sku,
-            outbound_type = outbound_type
+            outbound_type = outbound_type,
+            network_plugin = network_plugin
         )
         return self
 

--- a/python-lib/dku_azure/clusters.py
+++ b/python-lib/dku_azure/clusters.py
@@ -45,7 +45,7 @@ class ClusterBuilder(object):
         return self
 
     def with_network_profile(self, **kwargs):
-        self.network_profile = ContainerServiceNetworkProfile(kwargs)
+        self.network_profile = ContainerServiceNetworkProfile(**kwargs)
         return self
 
     def with_cluster_sp(self, cluster_service_principal_connection_info):

--- a/python-lib/dku_azure/clusters.py
+++ b/python-lib/dku_azure/clusters.py
@@ -101,8 +101,6 @@ class ClusterBuilder(object):
         if self.private_access:
             cluster_params["api_server_access_profile"] = self.private_access
             
-        
-        print(cluster_params)
         self.cluster_config = ManagedCluster(**cluster_params)
         return self.clusters_client.managed_clusters.create_or_update(self.resource_group, self.name, self.cluster_config)
 

--- a/python-lib/dku_azure/clusters.py
+++ b/python-lib/dku_azure/clusters.py
@@ -57,6 +57,7 @@ class ClusterBuilder(object):
                 dns_service_ip = dns_service_ip,
                 load_balancer_profile = load_balancer_profile
             )
+            print(ContainerServiceNetworkProfile.load_balancer_profile)
         return self
 
     def with_cluster_sp(self, cluster_service_principal_connection_info):

--- a/python-lib/dku_azure/clusters.py
+++ b/python-lib/dku_azure/clusters.py
@@ -44,7 +44,7 @@ class ClusterBuilder(object):
         self.linux_profile = linux_profile
         return self
 
-    def with_network_profile(self, service_cidr, dns_service_ip, load_balancer_sku=None, load_balancer_profile=None):
+    def with_network_profile(self, service_cidr, dns_service_ip, load_balancer_sku=None, outbound_type=None):
         if load_balancer_sku:
             self.network_profile = ContainerServiceNetworkProfile(
                 service_cidr = service_cidr,
@@ -55,7 +55,7 @@ class ClusterBuilder(object):
             self.network_profile = ContainerServiceNetworkProfile(
                 service_cidr = service_cidr,
                 dns_service_ip = dns_service_ip,
-                load_balancer_profile = load_balancer_profile
+                outbound_type = outbound_type
             )
         return self
 

--- a/python-lib/dku_azure/clusters.py
+++ b/python-lib/dku_azure/clusters.py
@@ -57,7 +57,6 @@ class ClusterBuilder(object):
                 dns_service_ip = dns_service_ip,
                 load_balancer_profile = load_balancer_profile
             )
-            print(self.network_profile.load_balancer_profile)
         return self
 
     def with_cluster_sp(self, cluster_service_principal_connection_info):

--- a/python-lib/dku_azure/clusters.py
+++ b/python-lib/dku_azure/clusters.py
@@ -45,7 +45,7 @@ class ClusterBuilder(object):
         return self
 
     def with_network_profile(self, **kwargs):
-        self.network_profile = ContainerServiceNetworkProfile(**kwargs)
+        self.network_profile = ContainerServiceNetworkProfile(kwargs)
         return self
 
     def with_cluster_sp(self, cluster_service_principal_connection_info):

--- a/python-lib/dku_azure/clusters.py
+++ b/python-lib/dku_azure/clusters.py
@@ -97,8 +97,6 @@ class ClusterBuilder(object):
         if self.private_access:
             cluster_params["api_server_access_profile"] = self.private_access
             
-        if self.load_balancer_profile:
-            cluster_params["network_profile"] = self.load_balancer_profile
 
         self.cluster_config = ManagedCluster(**cluster_params)
         return self.clusters_client.managed_clusters.create_or_update(self.resource_group, self.name, self.cluster_config)

--- a/python-lib/dku_azure/clusters.py
+++ b/python-lib/dku_azure/clusters.py
@@ -45,18 +45,24 @@ class ClusterBuilder(object):
         return self
 
     def with_network_profile(self, service_cidr, dns_service_ip, load_balancer_sku=None, outbound_type=None):
-        if load_balancer_sku:
-            self.network_profile = ContainerServiceNetworkProfile(
-                service_cidr = service_cidr,
-                dns_service_ip = dns_service_ip,
-                load_balancer_sku = load_balancer_sku
-            )
-        else:
-            self.network_profile = ContainerServiceNetworkProfile(
-                service_cidr = service_cidr,
-                dns_service_ip = dns_service_ip,
-                outbound_type = outbound_type
-            )
+        self.network_profile = ContainerServiceNetworkProfile(
+            service_cidr = service_cidr,
+            dns_service_ip = dns_service_ip,
+            load_balancer_sku = load_balancer_sku,
+            outbound_type = outbound_type
+        )
+#         if load_balancer_sku:
+#             self.network_profile = ContainerServiceNetworkProfile(
+#                 service_cidr = service_cidr,
+#                 dns_service_ip = dns_service_ip,
+#                 load_balancer_sku = load_balancer_sku
+#             )
+#         else:
+#             self.network_profile = ContainerServiceNetworkProfile(
+#                 service_cidr = service_cidr,
+#                 dns_service_ip = dns_service_ip,
+#                 outbound_type = outbound_type
+#             )
         return self
 
     def with_cluster_sp(self, cluster_service_principal_connection_info):


### PR DESCRIPTION
This PR is inspired from this architecture: https://docs.microsoft.com/en-us/azure/aks/limit-egress-traffic#restrict-egress-traffic-using-azure-firewall.

This enables private cluster endpoint, the ability to choose which networking plugin to use (kubenet vs Azure CNI), the ability to specify own custom docker bridge CIDR, and the outbound type of loadBalancer or userDefinedRouting.

This will support customers using Azure Firewall for restricting egress traffic or a vnet NAT.