### PR TITLE
Add Nodepool Labels & Taints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PLUGIN_VERSION=1.0.4
+PLUGIN_VERSION=1.0.5
 PLUGIN_ID=aks-clusters
 
 plugin:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ For more details, please see [the DSS reference documentation](https://doc.datai
 
 ## Release notes
 
+### v1.0.5
+- Add node labels and node taints to AKS nodepools
+
 ### v1.0.4
 - Fix `Test network connectivity` macro when the hostname is already an IP.
 

--- a/parameter-sets/node-pool-request/parameter-set.json
+++ b/parameter-sets/node-pool-request/parameter-set.json
@@ -86,6 +86,24 @@
             "type": "STRING",
             "mandatory": false,
             "visibilityCondition": "!model.useSameNetworkAsDSSHost"
+        },
+        {
+            "type": "SEPARATOR",
+            "label": "Kubernetes"
+        },
+        {
+            "name": "labels",
+            "label": "Nodepool Labels",
+            "description": "https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/",
+            "type": "KEY_VALUE_LIST",
+            "mandatory": false
+        },
+        {
+            "name": "taints",
+            "label": "Nodepool Taints",
+            "description": "https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/",
+            "type": "STRINGS",
+            "mandatory": false
         }
     ]
 }

--- a/parameter-sets/node-pool-request/parameter-set.json
+++ b/parameter-sets/node-pool-request/parameter-set.json
@@ -93,15 +93,15 @@
         },
         {
             "name": "labels",
-            "label": "Nodepool Labels",
+            "label": "Node Labels",
             "description": "https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/",
             "type": "KEY_VALUE_LIST",
             "mandatory": false
         },
         {
             "name": "taints",
-            "label": "Nodepool Taints",
-            "description": "https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/",
+            "label": "Node Taints",
+            "description": "WARNING: MUST CREATE AT LEAST ONE NODE POOL WITHOUT TAINTS. https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/",
             "type": "STRINGS",
             "mandatory": false
         }

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "aks-clusters",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "meta": {
         "label": "AKS clusters",
         "description": "Interact with or create Microsoft Azure Kubernetes Service clusters",

--- a/python-clusters/create-aks-cluster/cluster.py
+++ b/python-clusters/create-aks-cluster/cluster.py
@@ -106,6 +106,8 @@ class MyCluster(Cluster):
                                               max_num_nodes=node_pool_conf.get("maxNumNodes", None))
 
             node_pool_builder.with_disk_size_gb(disk_size_gb=node_pool_conf.get("osDiskSizeGb", 0))
+            node_pool_builder.with_node_labels(node_pool_conf.get("labels", None))
+            node_pool_builder.with_node_taints(node_pool_conf.get("taints", None))
             node_pool_builder.build()
             cluster_builder.with_node_pool(node_pool=node_pool_builder.agent_pool_profile)
         

--- a/python-lib/dku_azure/clusters.py
+++ b/python-lib/dku_azure/clusters.py
@@ -120,6 +120,8 @@ class NodePoolBuilder(object):
         self.idx = None
         self.agent_pool_profile = None
         self.gpu = None
+        self.labels = None
+        self.taints = None
 
 
     def with_name(self, name):
@@ -164,6 +166,19 @@ class NodePoolBuilder(object):
         else:
             self.num_nodes = num_nodes
         return self
+    
+    def with_node_labels(self, labels):
+        lbls = {}
+        if labels:
+            for label in labels:
+                lbls[label["from"]] = label["to"]
+            self.labels = lbls
+        return self
+    
+    def with_node_taints(self, taints):
+        if taints:
+            self.taints = taints
+        return self
 
     def with_disk_size_gb(self, disk_size_gb):
         if disk_size_gb == 0:
@@ -187,10 +202,12 @@ class NodePoolBuilder(object):
             agent_pool_profile_params["min_count"] = self.min_num_nodes
         if self.max_num_nodes:
             agent_pool_profile_params["max_count"] = self.max_num_nodes
+        if self.labels:
+            agent_pool_profile_params["node_labels"] = self.labels
+        if self.taints:
+            agent_pool_profile_params["node_taints"] = self.taints
 
         logging.info("Adding agent pool profile: %s" % agent_pool_profile_params)
 
         self.agent_pool_profile = ManagedClusterAgentPoolProfile(**agent_pool_profile_params)
         return self
-
-


### PR DESCRIPTION
Add the ability to put nodepool labels and taints. Modified the nodepool parameter set to include the labels and taints. The labels should be inputted as key/value pairs, and the taints should be inputted as a list of strings, where the format of each string follows the convention provided by kubernetes: `key=value:NoSchedule`.