### PR TITLE
Always set min_count and max_count if autoscaling in enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PLUGIN_VERSION=1.0.5
+PLUGIN_VERSION=1.0.6
 PLUGIN_ID=aks-clusters
 
 plugin:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ For more details, please see [the DSS reference documentation](https://doc.datai
 
 ## Release notes
 
+### v1.0.6
+- Allow nodepools with a minimum of 0 nodes (allowed for user node pools)
+
 ### v1.0.5
 - Add node labels and node taints to AKS nodepools
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "aks-clusters",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "meta": {
         "label": "AKS clusters",
         "description": "Interact with or create Microsoft Azure Kubernetes Service clusters",

--- a/python-lib/dku_azure/clusters.py
+++ b/python-lib/dku_azure/clusters.py
@@ -9,7 +9,7 @@ import logging
 class ClusterBuilder(object):
     """
     """
-    
+
     def __init__(self, clusters_client):
         self.clusters_client = clusters_client
         self.name = None
@@ -73,8 +73,8 @@ class ClusterBuilder(object):
     def get_node_pool_builder(self):
         nb_node_pools = len(self.node_pools)
         return NodePoolBuilder(self).with_name("node-pool-{}".format(nb_node_pools))
-    
-        
+
+
     def with_cluster_version(self, cluster_version):
         if cluster_version != "latest":
             self.cluster_version = cluster_version
@@ -96,7 +96,7 @@ class ClusterBuilder(object):
 
         if self.private_access:
             cluster_params["api_server_access_profile"] = self.private_access
-            
+
         self.cluster_config = ManagedCluster(**cluster_params)
         return self.clusters_client.managed_clusters.create_or_update(self.resource_group, self.name, self.cluster_config)
 
@@ -131,7 +131,7 @@ class NodePoolBuilder(object):
     def with_idx(self, idx):
         self.idx = idx
         return self
-    
+
     def with_vm_size(self, vm_size):
         self.vm_size = vm_size
         return self
@@ -166,7 +166,7 @@ class NodePoolBuilder(object):
         else:
             self.num_nodes = num_nodes
         return self
-    
+
     def with_node_labels(self, labels):
         lbls = {}
         if labels:
@@ -174,7 +174,7 @@ class NodePoolBuilder(object):
                 lbls[label["from"]] = label["to"]
             self.labels = lbls
         return self
-    
+
     def with_node_taints(self, taints):
         if taints:
             self.taints = taints

--- a/python-lib/dku_azure/clusters.py
+++ b/python-lib/dku_azure/clusters.py
@@ -197,10 +197,9 @@ class NodePoolBuilder(object):
         agent_pool_profile_params["count"] = self.num_nodes
         agent_pool_profile_params["os_disk_size_gb"] = self.disk_size_gb
         agent_pool_profile_params["vnet_subnet_id"] = self.subnet_id
-        agent_pool_profile_params["enable_auto_scaling"] = self.enable_autoscaling
-        if self.min_num_nodes:
+        if self.enable_autoscaling:
+            agent_pool_profile_params["enable_auto_scaling"] = self.enable_autoscaling
             agent_pool_profile_params["min_count"] = self.min_num_nodes
-        if self.max_num_nodes:
             agent_pool_profile_params["max_count"] = self.max_num_nodes
         if self.labels:
             agent_pool_profile_params["node_labels"] = self.labels


### PR DESCRIPTION
This allow for `min_count` to be set even if it equals zero, which AKS allows for a user node pool.

Fixes #17 