### PR TITLE
Vnet attach, DSS identity and bugfixes

### DIFF
--- a/parameter-sets/cluster-identity/parameter-set.json
+++ b/parameter-sets/cluster-identity/parameter-set.json
@@ -26,13 +26,22 @@
             "mandatory" : true
         },
         {
+            "name": "inheritDSSIdentity",
+            "label": "Inherit DSS identity (Recommended)",
+            "description": "Assign DSS identity to both Control Plane and Kubelets",
+            "type": "BOOLEAN",
+            "mandatory": false,
+            "defaultValue": true,
+            "visibilityCondition": "model.identityType=='managed-identity'"
+        },
+        {
             "name": "useAKSManagedIdentity",
             "label": "AKS managed identity",
             "description": "Control plane gets a System Assigned Managed Identity handled by AKS",
             "type": "BOOLEAN",
             "mandatory": true,
-            "defaultValue": true,
-            "visibilityCondition": "model.identityType=='managed-identity'"
+            "defaultValue": false,
+            "visibilityCondition": "model.identityType=='managed-identity' && !model.inheritDSSIdentity"
         },
         {
             "name": "controlPlaneUserAssignedIdentity",
@@ -40,7 +49,16 @@
             "type": "STRING",
             "mandatory" : false,
             "description": "Resource ID of User Assigned Managed Identity for the control plane",
-            "visibilityCondition": "model.identityType=='managed-identity' && !model.useAKSManagedIdentity"
+            "visibilityCondition": "model.identityType=='managed-identity' && !model.useAKSManagedIdentity && !model.inheritDSSIdentity"
+        },
+        {
+            "name": "attachToVnet",
+            "label": "Assign permissions for Vnet",
+            "type": "BOOLEAN",
+            "default": true,
+            "mandatory" : false,
+            "description": "Add the Contributor role onto the Vnet to allow creation of LBs by the Control Plane",
+            "visibilityCondition": "model.identityType=='managed-identity' && model.useAKSManagedIdentity && !model.inheritDSSIdentity"
         },
         {
             "name": "useAKSManagedKubeletIdentity",
@@ -48,8 +66,8 @@
             "description": "Kubelets get a User Assigned Managed Identity created and handled by AKS",
             "type": "BOOLEAN",
             "mandatory": true,
-            "defaultValue": true,
-            "visibilityCondition": "model.identityType=='managed-identity'"
+            "defaultValue": false,
+            "visibilityCondition": "model.identityType=='managed-identity' && !model.inheritDSSIdentity"
         },
         {
             "name": "kubeletUserAssignedIdentity",
@@ -57,15 +75,15 @@
             "type": "STRING",
             "mandatory" : false,
             "description": "User Assigned Managed Identity for the kubelets. Only available with Azure feature Microsoft.ContainerService/CustomKubeletIdentityPreview. See documentation.",
-            "visibilityCondition": "model.identityType=='managed-identity' && !model.useAKSManagedKubeletIdentity"
+            "visibilityCondition": "model.identityType=='managed-identity' && !model.useAKSManagedKubeletIdentity && !model.inheritDSSIdentity"
         },
         {
             "name": "attachToACRName",
-            "label": "Attach to ACR",
+            "label": "Assign permissions for ACR",
             "type": "STRING",
             "mandatory" : false,
             "description": "Name of the ACR to attach to. Syntax \"[RESOURCE_GROUP/]NAME\".  RESOURCE_GROUP defaults to the same as the cluster.",
-            "visibilityCondition": "model.identityType=='managed-identity' && model.useAKSManagedKubeletIdentity"
+            "visibilityCondition": "model.identityType=='managed-identity' && model.useAKSManagedKubeletIdentity && !model.inheritDSSIdentity"
         },
         {
             "name": "clientId",

--- a/parameter-sets/cluster-identity/parameter-set.json
+++ b/parameter-sets/cluster-identity/parameter-set.json
@@ -2,7 +2,7 @@
     "meta" : {
         "label" : "AKS Cluster identity",
         "pluralLabel": "AKS Clusters Identities",
-        "description" : "AKS Components identity management (control plane, kubelets)",
+        "description" : "Identities assumed by AKS control plane and Kubelets",
         "icon" : "icon-link"
     },
     

--- a/parameter-sets/connection-info-v2/parameter-set.json
+++ b/parameter-sets/connection-info-v2/parameter-set.json
@@ -19,28 +19,19 @@
             "description": "Select the type of identity",
             "type": "SELECT",
             "selectChoices": [
-                {"value": "default", "label": "Default credentials, from environment or System Assigned Managed Identity"},
-                {"value": "user-assigned-client-id", "label": "User Assigned Managed Identity - Client Id"},
-                {"value": "user-assigned-resource-id", "label": "User Assigned Managed Identity - Resource Id"},
+                {"value": "default", "label": "Default credentials, from environment or System/User Assigned Managed Identity"},
+                {"value": "user-assigned", "label": "User Assigned Managed Identity"},
                 {"value": "service-principal", "label": "App registration"}
             ],
             "defaultValue": "default"
         },
         {
-            "name": "userManagedIdentityClientId",
-            "label": "Client ID",
+            "name": "userManagedIdentityId",
+            "label": "User Assigned Managed Id",
             "type": "STRING",
             "mandatory" : false,
-            "description": "Client ID of User Assigned Managed Identity",
-            "visibilityCondition": "model.identityType=='user-assigned-client-id'"
-        },
-        {
-            "name": "userManagedIdentityResourceId",
-            "label": "Resource ID",
-            "type": "STRING",
-            "mandatory" : false,
-            "description": "Resource ID of User Assigned Managed Identity",
-            "visibilityCondition": "model.identityType=='user-assigned-resource-id'"
+            "description": "Client ID or Resource ID of User Assigned Managed Identity",
+            "visibilityCondition": "model.identityType=='user-assigned'"
         },
         {
             "name": "tenantId",

--- a/parameter-sets/connection-info-v2/parameter-set.json
+++ b/parameter-sets/connection-info-v2/parameter-set.json
@@ -1,8 +1,8 @@
 {
     "meta" : {
-        "label" : "AKS connections",
-        "pluralLabel": "AKS connections",
-        "description" : "AKS connection settings",
+        "label" : "Azure credentials",
+        "pluralLabel": "Azure credentials",
+        "description" : "Identity and credentials used by DSS to create and join AKS clusters",
         "icon" : "icon-link"
     },
     

--- a/parameter-sets/connection-info/parameter-set.json
+++ b/parameter-sets/connection-info/parameter-set.json
@@ -2,7 +2,7 @@
     "meta" : {
         "label" : "AKS connection (Legacy)",
         "pluralLabel": "AKS connections (Legacy)",
-        "description" : "AKS connection legacy settings are available for backward compatbility with previous versions. Consider using the non-legacy one.",
+        "description" : "AKS connection legacy settings are available for backward compatbility with previous versions. Consider using Azure credentials settings instead.",
         "icon" : "icon-link"
     },
     

--- a/python-clusters/attach-aks-cluster/cluster.json
+++ b/python-clusters/attach-aks-cluster/cluster.json
@@ -17,7 +17,7 @@
         },
         {
             "name": "connectionInfoV2",
-            "label" : "Connection",
+            "label" : "Credentials",
             "type": "PRESET",
             "parameterSetId" : "connection-info-v2",
             "mandatory" : true

--- a/python-clusters/attach-aks-cluster/cluster.py
+++ b/python-clusters/attach-aks-cluster/cluster.py
@@ -24,7 +24,7 @@ class MyCluster(Cluster):
             subscription_id = connection_info.get('subscriptionId', None)
         else:
             connection_info_v2 = self.config.get("connectionInfoV2",{"identityType":"default"})
-            credentials = get_credentials_from_connection_infoV2(connection_info_v2)
+            credentials, _ = get_credentials_from_connection_infoV2(connection_info_v2)
             subscription_id = get_subscription_id(connection_info_v2)
         return credentials, subscription_id
         

--- a/python-clusters/create-aks-cluster/cluster.json
+++ b/python-clusters/create-aks-cluster/cluster.json
@@ -15,7 +15,7 @@
         },
         {
             "name": "connectionInfoV2",
-            "label": "Connection",
+            "label": "Credentials",
             "type": "PRESET",
             "parameterSetId": "connection-info-v2",
             "mandatory": true

--- a/python-clusters/create-aks-cluster/cluster.py
+++ b/python-clusters/create-aks-cluster/cluster.py
@@ -422,9 +422,7 @@ class MyCluster(Cluster):
         vnet_attachment = data.get("vnet_attachment", None)
         if not _is_none_or_blank(vnet_attachment):
             logging.info("Cluster has an Vnet attachment, check managed identity")
-            #cluster_identity_profile = data["cluster"]["identity_profile"]
-            controle_plane_mi_id = None
-            if  controle_plane_mi_id is not None and "role_assignment" in vnet_attachment:
+            if "role_assignment" in vnet_attachment:
                 logging.info("Cluster has an AKS managed kubelet identity, try to detach")
                 authorization_client = AuthorizationManagementClient(credentials, vnet_attachment["subscription_id"])
                 try:

--- a/python-clusters/create-aks-cluster/cluster.py
+++ b/python-clusters/create-aks-cluster/cluster.py
@@ -2,6 +2,7 @@ import os, json, logging, yaml, time, uuid
 from dataiku.cluster import Cluster
 
 from azure.mgmt.containerservice import ContainerServiceClient
+from azure.mgmt.compute import ComputeManagementClient
 from azure.mgmt.msi import ManagedServiceIdentityClient
 from azure.mgmt.authorization import AuthorizationManagementClient
 from azure.core.pipeline.policies import UserAgentPolicy
@@ -23,6 +24,7 @@ class MyCluster(Cluster):
         self.plugin_config = plugin_config
 
     def _get_credentials(self):
+        managed_identity_id = None
         connection_info = self.config.get("connectionInfo", None)
         connection_info_secret = self.plugin_config.get("connectionInfo", None)
         if not _is_none_or_blank(connection_info) or not _is_none_or_blank(connection_info_secret):
@@ -31,17 +33,18 @@ class MyCluster(Cluster):
             subscription_id = connection_info.get('subscriptionId', None)
         else:
             connection_info_v2 = self.config.get("connectionInfoV2",{"identityType":"default"})
-            credentials = get_credentials_from_connection_infoV2(connection_info_v2)
+            credentials, managed_identity_id = get_credentials_from_connection_infoV2(connection_info_v2)
             subscription_id = get_subscription_id(connection_info_v2)
-        return credentials, subscription_id
+        return credentials, subscription_id, managed_identity_id
 
     def start(self):
         """
         Build the create cluster request.
         """
-        credentials, subscription_id = self._get_credentials()
+        credentials, subscription_id, managed_identity_id = self._get_credentials()
 
         # Fetch metadata should we need them
+        metadata = None
         if self.config.get("useSameResourceGroupAsDSSHost",True) or self.config.get("useSameLocationAsDSSHost",True):
             metadata = get_instance_metadata()
 
@@ -122,19 +125,37 @@ class MyCluster(Cluster):
             cluster_identity = self.config.get("clusterIdentity",{"identityType":"managed-identity"})  
             cluster_identity_type = cluster_identity.get("identityType", "managed-identity")
             if cluster_identity_type == "managed-identity":
-                control_plane_mi = None if cluster_identity.get("useAKSManagedIdentity",True) else cluster_identity["controlPlaneUserAssignedIdentity"]
-                cluster_builder.with_managed_identity(control_plane_mi)
-                if control_plane_mi is None:
-                    logging.info("Configure cluster with system managed identity.")
+                if cluster_identity.get("inheritDSSIdentity",True):
+                    logging.info("Need to inspect Managed Identity infos from Azure")
+                    if metadata is None:
+                        metadata = get_instance_metadata()
+                    vm_resource_group = metadata["compute"]["resourceGroupName"]
+                    vm_name = metadata["compute"]["name"]
+                    compute_client = ComputeManagementClient(credentials, subscription_id)
+                    vm = compute_client.virtual_machines.get(vm_resource_group, vm_name)
+                    # No choice here but to use the first one
+                    if managed_identity_id is None:
+                        managed_identity_id = next(iter(vm.identity.user_assigned_identities.keys()))
+                    for managed_identity_resource_id, managed_identity_properties in vm.identity.user_assigned_identities.items():
+                        if managed_identity_id == managed_identity_resource_id or managed_identity_id == managed_identity_properties.client_id:
+                            break
+                    logging.info("Found managed identity id {}".format(managed_identity_resource_id))
+                    cluster_builder.with_managed_identity(managed_identity_resource_id)
+                    cluster_builder.with_kubelet_identity(managed_identity_resource_id, managed_identity_properties.client_id, managed_identity_properties.principal_id)     
                 else:
-                    logging.info("Configure cluster with user assigned identity: {}".format(control_plane_mi))
-                if not cluster_identity.get("useAKSManagedKubeletIdentity",True):
-                    kubelet_mi = cluster_identity["kubeletUserAssignedIdentity"]
-                    _,_,mi_subscription_id,_,mi_resource_group,_,_,_,mi_name = kubelet_mi.split("/")
-                    msiclient = ManagedServiceIdentityClient(AzureIdentityCredentialAdapter(credentials), mi_subscription_id)
-                    mi = msiclient.user_assigned_identities.get(mi_resource_group, mi_name)
-                    cluster_builder.with_kubelet_identity(kubelet_mi, mi.client_id, mi.principal_id)
-                    logging.info("Configure kubelet identity with user assigned identity resourceId=\"{}\", clientId=\"{}\", objectId=\"{}\"".format(kubelet_mi, mi.client_id, mi.principal_id))
+                    control_plane_mi = None if cluster_identity.get("useAKSManagedIdentity",True) else cluster_identity["controlPlaneUserAssignedIdentity"]
+                    cluster_builder.with_managed_identity(control_plane_mi)
+                    if control_plane_mi is None:
+                        logging.info("Configure cluster with system managed identity.")
+                    else:
+                        logging.info("Configure cluster with user assigned identity: {}".format(control_plane_mi))
+                    if not cluster_identity.get("useAKSManagedKubeletIdentity",True):
+                        kubelet_mi = cluster_identity["kubeletUserAssignedIdentity"]
+                        _,_,mi_subscription_id,_,mi_resource_group,_,_,_,mi_name = kubelet_mi.split("/")
+                        msiclient = ManagedServiceIdentityClient(AzureIdentityCredentialAdapter(credentials), mi_subscription_id)
+                        mi = msiclient.user_assigned_identities.get(mi_resource_group, mi_name)
+                        cluster_builder.with_kubelet_identity(kubelet_mi, mi.client_id, mi.principal_id)
+                        logging.info("Configure kubelet identity with user assigned identity resourceId=\"{}\", clientId=\"{}\", objectId=\"{}\"".format(kubelet_mi, mi.client_id, mi.principal_id))
             elif cluster_identity_type == "service-principal":
                 cluster_builder.with_cluster_sp(cluster_identity["clientId"], cluster_identity["password"])
                 logging.info("Configure cluster with service principal")
@@ -144,8 +165,9 @@ class MyCluster(Cluster):
 
         # Fail fast for non existing ACRs to avoid drama in case of failure AFTER cluster is created
         acr_role_id = None
+        authorization_client = None
         if cluster_identity_type is not None and cluster_identity is not None:
-            if cluster_identity_type == "managed-identity" and cluster_identity.get("useAKSManagedKubeletIdentity",True):
+            if cluster_identity_type == "managed-identity" and cluster_identity.get("useAKSManagedKubeletIdentity",True) and not cluster_identity.get("inheritDSSIdentity", True):
                 acr_name = cluster_identity.get("attachToACRName", None)
                 if not _is_none_or_blank(acr_name):
                     # build acr scope
@@ -190,8 +212,65 @@ class MyCluster(Cluster):
                             raise(e)
                     except Exception as e:
                         raise(e)
-                    
-
+                        
+        # Sanity check for node pools
+        node_pool_vnets = set()
+        for idx, node_pool_conf in enumerate(self.config.get("nodePools", [])):
+            node_pool_builder = cluster_builder.get_node_pool_builder()
+            nodepool_vnet = node_pool_conf.get("vnet", None)
+            nodepool_subnet = node_pool_conf.get("subnet", None)
+            vnet, _ = node_pool_builder.resolve_network(inherit_from_host=node_pool_conf.get("useSameNetworkAsDSSHost"),
+                                           cluster_vnet=nodepool_vnet,
+                                           cluster_subnet=nodepool_subnet,
+                                           connection_info=connection_info,
+                                           credentials=credentials,
+                                           resource_group=resource_group)
+            node_pool_vnets.add(vnet)
+            
+        if 1 < len(node_pool_vnets):
+            raise Exception("Node pools must all share the same vnet. Current node pools configuration yields vnets {}.".format(",".join(node_pool_vnets)))
+        elif 0 == len(node_pool_vnets):
+            raise Exception("You cannot deploy a cluster without any node pool.")
+        
+        # Check role assignments for vnet like on ACR for fail fast if not doable
+        vnet_id = node_pool_vnets.pop()
+        if not vnet_id.startswith("/"):
+            vnet_name = vnet_id
+            vnet_id = "/subscriptions/{subscription_id}/resourceGroups/{resource_group}/providers/Microsoft.Network/virtualNetworks/{vnet_name}".format(**locals())
+        vnet_role_id = None
+        if cluster_identity_type is not None and cluster_identity is not None:
+            if cluster_identity_type == "managed-identity" and cluster_identity.get("useAKSManagedIdentity",True) and not cluster_identity.get("inheritDSSIdentity", True):
+                authorization_client = AuthorizationManagementClient(credentials, subscription_id)
+                try:
+                    vnet_roles = list(authorization_client.role_definitions.list(vnet_id,"roleName eq 'Contributor'"))
+                except ResourceNotFoundError as e:
+                    raise Exception("Vnet {} not found. Check it exists and you are Owner of it.".format(vnet_id))
+                if 0 == len(acr_roles):
+                    raise Exception("Could not find the Contributor role on the vnet {}. Check you are Owner of it.".format(vnet_id))
+                else:
+                    vnet_role_id = vnet_roles[0].id
+                    logging.info("Vnet contributor role id: %s", acr_role_id)              
+                    # Try to run a fake role assignment. Depending on the failure type we know if we are Owner or not
+                    try:
+                        fake_role_assignment = authorization_client.role_assignments.create(
+                            scope=vnet_id,
+                            role_assignment_name=str(uuid.uuid4()),
+                            parameters= {
+                                "properties": {
+                                    "role_definition_id": vnet_role_id,
+                                    "principal_id": "00000000-0000-0000-0000-000000000000",
+                                },
+                            },
+                        )
+                    except HttpResponseError as e:
+                        if e.reason == "Forbidden" and "AuthorizationFailed" in str(e.error):
+                            raise Exception("Cannot create role assignments on Vnet {}. Check that your are Owner of it or provide an existing Controle Plane identity.".format(vnet_id))
+                        elif e.reason == "Bad Request" and "PrincipalNotFound" in str(e.error):
+                            logging.info("Fake role assignment on Vnet looks ok. Identity should be allowed to assign roles in further steps.")
+                        else:
+                            raise(e)
+                    except Exception as e:
+                        raise(e)
 
         # Access level
         if self.config.get("privateAccess"):
@@ -245,7 +324,7 @@ class MyCluster(Cluster):
         # Attach to ACR
         acr_attachment = {}
         if cluster_identity_type is not None and cluster_identity is not None:
-            if cluster_identity_type == "managed-identity" and cluster_identity.get("useAKSManagedKubeletIdentity",True):
+            if cluster_identity_type == "managed-identity" and cluster_identity.get("useAKSManagedKubeletIdentity",True) and not cluster_identity.get("inheritDSSIdentity", True):
                 kubelet_mi_object_id = create_result.identity_profile.get("kubeletidentity").object_id
                 logging.info("Kubelet Managed Identity object id: %s", kubelet_mi_object_id)
                 if not _is_none_or_blank(acr_role_id):
@@ -267,6 +346,31 @@ class MyCluster(Cluster):
                         "resource_id": acr_scope,
                         "role_assignment": role_assignment.as_dict(),
                     })
+                    
+        # Attach to VNET to allow LoadBalancers creation
+        vnet_attachment = {}
+        if cluster_identity_type is not None and cluster_identity is not None:
+            if cluster_identity_type == "managed-identity" and cluster_identity.get("useAKSManagedIdentity",True) and not cluster_identity.get("inheritDSSIdentity", True):
+                # And here we are blocked because we cant get the principal id of a System Assigned Managed Id easily
+                control_plane_object_id = create_result.identity.principal_id
+                logging.info("Controle Plane Managed Identity object id: %s", control_plane_object_id)
+                if not _is_none_or_blank(vnet_role_id):
+                    logging.info("Assign Vnet contributolr role id %s to %s", vnet_role_id, control_plane_object_id)
+                    vnet_role_assignment = authorization_client.role_assignments.create(
+                        scope=vnet_id,
+                        role_assignment_name=str(uuid.uuid4()),
+                        parameters= {
+                            "properties": {
+                                "role_definition_id": vnet_role_id,
+                                "principal_id": control_plane_object_id,
+                            },
+                        },
+                    )
+                    vnet_attachment.update({
+                        "subscription_id": subscription_id,
+                        "resource_id": vnet_id,
+                        "role_assignment": vnet_role_assignment.as_dict(),
+                    })
 
         logging.info("Fetching kubeconfig for cluster {} in {}...".format(self.cluster_name, resource_group))
         def do_fetch():
@@ -285,11 +389,11 @@ class MyCluster(Cluster):
                 acr_name = None if _is_none_or_blank(acr_attachment) else acr_attachment["name"],
         )
 
-        return [overrides, {"kube_config_path": kube_config_path, "cluster": create_result.as_dict(), "acr_attachment": acr_attachment}]
+        return [overrides, {"kube_config_path": kube_config_path, "cluster": create_result.as_dict(), "acr_attachment": acr_attachment, "vnet_attachment": vnet_attachment}]
 
 
     def stop(self, data):
-        credentials, _ = self._get_credentials()
+        credentials, _ , _ = self._get_credentials()
 
         # Do NOT use the conf but the actual values from the cluster here
         cluster_resource_id = data["cluster"]["id"]
@@ -313,7 +417,20 @@ class MyCluster(Cluster):
                         authorization_client.role_assignments.delete_by_id(acr_attachment["role_assignment"]["id"])
                     except ResourceNotFoundError as e:
                         logging.warn("It looks that the ACR role assignment doesnt exist. Ignore this step")
-
+        
+        # Detach Vnet like ACR
+        vnet_attachment = data.get("vnet_attachment", None)
+        if not _is_none_or_blank(vnet_attachment):
+            logging.info("Cluster has an Vnet attachment, check managed identity")
+            #cluster_identity_profile = data["cluster"]["identity_profile"]
+            controle_plane_mi_id = None
+            if  controle_plane_mi_id is not None and "role_assignment" in vnet_attachment:
+                logging.info("Cluster has an AKS managed kubelet identity, try to detach")
+                authorization_client = AuthorizationManagementClient(credentials, vnet_attachment["subscription_id"])
+                try:
+                    authorization_client.role_assignments.delete_by_id(vnet_attachment["role_assignment"]["id"])
+                except ResourceNotFoundError as e:
+                    logging.warn("It looks that the Vnet role assignment doesnt exist. Ignore this step")
 
         def do_delete():
             future = clusters_client.managed_clusters.begin_delete(resource_group, cluster_name)

--- a/python-lib/dku_azure/auth.py
+++ b/python-lib/dku_azure/auth.py
@@ -22,12 +22,15 @@ def get_credentials_from_connection_infoV2(connection_infos):
     infos = connection_infos
     user_managed_identity = infos.get('userManagedIdentity', None)
     identity_type = infos.get('identityType','default')
+    managed_identity_id = None
     if identity_type == 'default':
         credentials = DefaultAzureCredential()
-    elif identity_type == 'user-assigned-client-id':
-        credentials = ManagedIdentityCredential(client_id=infos.get('userManagedIdentityClientId',None))
-    elif identity_type == 'user-assigned-resource-id':
-        credentials = ManagedIdentityCredential(identity_config={'msi_res_id': infos.get('userManagedIdentityResourceId',None)})
+    elif identity_type == 'user-assigned':
+        managed_identity_id = infos.get('userManagedIdentityId')
+        if managed_identity_id.startswith("/"):
+            credentials = ManagedIdentityCredential(identity_config={'msi_res_id': managed_identity_id})
+        else:
+            credentials = ManagedIdentityCredential(client_id=managed_identity_id)
     elif identity_type == 'service-principal':
         client_id = infos.get('clientId', None)
         password = infos.get('password', None)
@@ -36,7 +39,7 @@ def get_credentials_from_connection_infoV2(connection_infos):
     else:
         raise Exception("Identity type {} is unknown and cannot be used".format(identity_type))
 
-    return credentials
+    return credentials, managed_identity_id
 
 
 

--- a/python-lib/dku_azure/clusters.py
+++ b/python-lib/dku_azure/clusters.py
@@ -206,17 +206,22 @@ class NodePoolBuilder(object):
                 self.tags = {}
             self.tags.update(tags)
         return self
-
-    def with_network(self, inherit_from_host, cluster_vnet, cluster_subnet, connection_info, credentials, resource_group):
+    
+    def resolve_network(self, inherit_from_host, cluster_vnet, cluster_subnet, connection_info, credentials, resource_group):
+        vnet, subnet_id = None, None
         if inherit_from_host:
             logging.info("Inheriting VNET/subnet from DSS host")
-            self.vnet, self.subnet_id = get_host_network(credentials=credentials,
+            vnet, subnet_id = get_host_network(credentials=credentials,
                                                          resource_group=resource_group,
                                                          connection_info=connection_info)
         else:
             logging.info("Using custom VNET ({}) and subnet ({}) for cluster".format(cluster_vnet, cluster_subnet))
-            self.vnet = cluster_vnet
-            self.subnet_id = get_subnet_id(resource_group=resource_group, connection_info=connection_info, vnet=cluster_vnet, subnet=cluster_subnet)
+            vnet = cluster_vnet
+            subnet_id = get_subnet_id(resource_group=resource_group, connection_info=connection_info, vnet=cluster_vnet, subnet=cluster_subnet)
+        return vnet, subnet_id
+
+    def with_network(self, inherit_from_host, cluster_vnet, cluster_subnet, connection_info, credentials, resource_group):
+        self.vnet, self.subnet_id = self.resolve_network(inherit_from_host, cluster_vnet, cluster_subnet, connection_info, credentials, resource_group)
         return self
 
     def with_node_count(self, enable_autoscaling, num_nodes, min_num_nodes, max_num_nodes):

--- a/python-lib/dku_utils/cluster.py
+++ b/python-lib/dku_utils/cluster.py
@@ -34,7 +34,7 @@ def get_cluster_from_connection_info(config, plugin_config):
         subscription_id = connection_info.get('subscriptionId', None)
     else:
         connection_info_v2 = config.get("connectionInfoV2",{"identityType":"default"})
-        credentials = get_credentials_from_connection_infoV2(connection_info_v2)
+        credentials, _ = get_credentials_from_connection_infoV2(connection_info_v2)
         subscription_id = get_subscription_id(connection_info_v2)
     clusters_client = ContainerServiceClient(credentials, subscription_id)
     return clusters_client


### PR DESCRIPTION
Implements:
- Vnet auto attach and detach for auto-generated managed IDs
- Defaults to inheriting DSS managed id
- Implements @FChataigner suggestion to merge modes "Client ID " and "Resource Id" based on actual value*
- Fail fast for role assignments if not Owner (before cluster creation)