### PR TITLE
Always use DSS host resource group when node pool inherits vnet settings

### DIFF
--- a/python-clusters/create-aks-cluster/cluster.py
+++ b/python-clusters/create-aks-cluster/cluster.py
@@ -50,8 +50,9 @@ class MyCluster(Cluster):
 
         # Resource group
         resource_group = self.config.get('resourceGroup', None)
+        dss_host_resource_group = metadata["compute"]["resourceGroupName"]
         if _is_none_or_blank(resource_group):
-            resource_group = metadata["compute"]["resourceGroupName"]
+            resource_group = dss_host_resource_group
             logging.info("Using same resource group as DSS: {}".format(resource_group))
 
         # Location
@@ -224,7 +225,8 @@ class MyCluster(Cluster):
                                            cluster_subnet=nodepool_subnet,
                                            connection_info=connection_info,
                                            credentials=credentials,
-                                           resource_group=resource_group)
+                                           resource_group=resource_group,
+                                           dss_host_resource_group=dss_host_resource_group)
             node_pool_vnets.add(vnet)
             
         if 1 < len(node_pool_vnets):
@@ -290,7 +292,8 @@ class MyCluster(Cluster):
                                            cluster_subnet=subnet,
                                            connection_info=connection_info,
                                            credentials=credentials,
-                                           resource_group=resource_group)
+                                           resource_group=resource_group,
+                                           dss_host_resource_group=dss_host_resource_group)
 
             node_pool_builder.with_availability_zones(
                 use_availability_zones=node_pool_conf.get("useAvailabilityZones", True))

--- a/python-clusters/create-aks-cluster/cluster.py
+++ b/python-clusters/create-aks-cluster/cluster.py
@@ -43,10 +43,8 @@ class MyCluster(Cluster):
         """
         credentials, subscription_id, managed_identity_id = self._get_credentials()
 
-        # Fetch metadata should we need them
-        metadata = None
-        if self.config.get("useSameResourceGroupAsDSSHost",True) or self.config.get("useSameLocationAsDSSHost",True):
-            metadata = get_instance_metadata()
+        # Fetch metadata about the instance
+        metadata = get_instance_metadata()
 
         # Resource group
         resource_group = self.config.get('resourceGroup', None)

--- a/python-lib/dku_azure/clusters.py
+++ b/python-lib/dku_azure/clusters.py
@@ -207,12 +207,12 @@ class NodePoolBuilder(object):
             self.tags.update(tags)
         return self
     
-    def resolve_network(self, inherit_from_host, cluster_vnet, cluster_subnet, connection_info, credentials, resource_group):
+    def resolve_network(self, inherit_from_host, cluster_vnet, cluster_subnet, connection_info, credentials, resource_group, dss_host_resource_group):
         vnet, subnet_id = None, None
         if inherit_from_host:
             logging.info("Inheriting VNET/subnet from DSS host")
             vnet, subnet_id = get_host_network(credentials=credentials,
-                                                         resource_group=resource_group,
+                                                         resource_group=dss_host_resource_group,
                                                          connection_info=connection_info)
         else:
             logging.info("Using custom VNET ({}) and subnet ({}) for cluster".format(cluster_vnet, cluster_subnet))
@@ -220,8 +220,8 @@ class NodePoolBuilder(object):
             subnet_id = get_subnet_id(resource_group=resource_group, connection_info=connection_info, vnet=cluster_vnet, subnet=cluster_subnet)
         return vnet, subnet_id
 
-    def with_network(self, inherit_from_host, cluster_vnet, cluster_subnet, connection_info, credentials, resource_group):
-        self.vnet, self.subnet_id = self.resolve_network(inherit_from_host, cluster_vnet, cluster_subnet, connection_info, credentials, resource_group)
+    def with_network(self, inherit_from_host, cluster_vnet, cluster_subnet, connection_info, credentials, resource_group, dss_host_resource_group):
+        self.vnet, self.subnet_id = self.resolve_network(inherit_from_host, cluster_vnet, cluster_subnet, connection_info, credentials, resource_group, dss_host_resource_group)
         return self
 
     def with_node_count(self, enable_autoscaling, num_nodes, min_num_nodes, max_num_nodes):


### PR DESCRIPTION
In the case where the user specifies a custom resource group to deploy the cluster in, but wants the node pool to use the DSS's hosts network settings, we need to make sure we fetch the host's network settings with the host's resource group, and not the custom resource group.