### PR TITLE
Made <0.7 msrest dependency explicit

### DIFF
--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -8,5 +8,6 @@ azure-mgmt-core==1.2.2
 azure-mgmt-resource==18.0.0
 azure-mgmt-msi==1.0.0
 ipaddress==1.0.23
+msrest==0.6.21
 pyyaml==5.4.1
 uuid==1.30


### PR DESCRIPTION
Without this explicit dependency, trying to create an AKS cluster results in a `Failed to start cluster : <type 'exceptions.ImportError'> : cannot import name SerializationError` error. 