### PR TITLE
Chore/sc 110915 azure login

### DIFF
--- a/python-clusters/attach-aks-cluster/cluster.py
+++ b/python-clusters/attach-aks-cluster/cluster.py
@@ -6,7 +6,7 @@ from dku_utils.access import _is_none_or_blank
 from dku_utils.cluster import make_overrides, get_subscription_id
 from dku_azure.auth import get_credentials_from_connection_info, get_credentials_from_connection_infoV2
 from dku_azure.utils import run_and_process_cloud_error
-from dku_azure.utils import run_and_process_cloud_error, get_instance_metadata, get_subscription_id
+from dku_azure.utils import run_and_process_cloud_error, get_instance_metadata, get_subscription_id, patch_kube_config_with_aad
 
 class MyCluster(Cluster):
     def __init__(self, cluster_id, cluster_name, config, plugin_config):
@@ -30,6 +30,13 @@ class MyCluster(Cluster):
         
     def start(self):
         credentials, subscription_id = self._get_credentials()
+        connection_info = self.config.get("connectionInfoV2",{"identityType":"default"})
+        identity_type = connection_info.get("identityType", "default")
+        identity_label = None
+        if identity_type == 'user-assigned':
+            identity_label = connection_info.get("userManagedIdentityId", "")
+        elif identity_type == 'service-principal':
+            identity_label = connection_info.get("clientId", "")
 
         # Cluster name
         cluster_name = self.config.get("cluster", None)
@@ -50,18 +57,24 @@ class MyCluster(Cluster):
         def do_get():
             return clusters_client.managed_clusters.get(resource_group, cluster_name)
         get_cluster_result = run_and_process_cloud_error(do_get)
-        patch_user_in_kubeconfig = get_cluster_result.aad_profile.managed and get_cluster_result.aad_profile.enable_azure_rbac
+        print("Amandine - managed: {}".format(get_cluster_result.aad_profile.managed))
+        patch_user_in_kubeconfig = get_cluster_result.aad_profile.managed
 
         # Get kubeconfig 
         logging.info("Fetching kubeconfig for cluster %s in %s", cluster_name, resource_group)
         def do_fetch():
             return clusters_client.managed_clusters.list_cluster_admin_credentials(resource_group, cluster_name)
         get_credentials_result = run_and_process_cloud_error(do_fetch)
+
         kube_config_content = get_credentials_result.kubeconfigs[0].value.decode('utf8')
         kube_config_path = os.path.join(os.getcwd(), 'kube_config')
+        if patch_user_in_kubeconfig:
+            kube_config_yaml = patch_kube_config_with_aad(kube_config_content, identity_type, identity_label)
+        else:
+            kube_config_yaml = yaml.safe_load(kube_config_content)
         with open(kube_config_path, 'w') as f:
-            f.write(kube_config_content)
-        overrides = make_overrides(self.config, yaml.safe_load(kube_config_content), kube_config_path)
+            yaml.dump(kube_config_yaml, f)
+        overrides = make_overrides(self.config, kube_config_yaml, kube_config_path)
         
         # Get other cluster infos
         def do_inspect():

--- a/python-clusters/attach-aks-cluster/cluster.py
+++ b/python-clusters/attach-aks-cluster/cluster.py
@@ -46,6 +46,12 @@ class MyCluster(Cluster):
 
         clusters_client = ContainerServiceClient(credentials, subscription_id)
 
+        # Retrieve the cluster to check whether or not the Azure AD with Azure RBAC is activated
+        def do_get():
+            return clusters_client.managed_clusters.get(resource_group, cluster_name)
+        get_cluster_result = run_and_process_cloud_error(do_get)
+        patch_user_in_kubeconfig = get_cluster_result.aad_profile.managed and get_cluster_result.aad_profile.enable_azure_rbac
+
         # Get kubeconfig 
         logging.info("Fetching kubeconfig for cluster %s in %s", cluster_name, resource_group)
         def do_fetch():

--- a/python-lib/dku_azure/clusters.py
+++ b/python-lib/dku_azure/clusters.py
@@ -1,6 +1,6 @@
 from dku_azure.utils import get_instance_metadata, get_vm_resource_id, get_host_network, get_subnet_id
 from azure.mgmt.containerservice.models import ManagedClusterAgentPoolProfile, ManagedClusterAPIServerAccessProfile, ManagedClusterServicePrincipalProfile
-from azure.mgmt.containerservice.models import ContainerServiceNetworkProfile, ManagedCluster, ManagedClusterIdentity
+from azure.mgmt.containerservice.models import ContainerServiceNetworkProfile, ManagedCluster, ManagedClusterAADProfile
 from dku_utils.access import _default_if_blank, _merge_objects, _print_as_json
 
 import logging, copy, json
@@ -147,6 +147,7 @@ class ClusterBuilder(object):
         cluster_params["node_resource_group"] = self.node_resource_group
         cluster_params["service_principal_profile"] = self.cluster_sp
         cluster_params["identity"] = self.identity
+        cluster_params["aad_profile"] = ManagedClusterAADProfile(managed=True, enable_azure_rbac=True)
         cluster_params["identity_profile"] = self.identity_profile
         cluster_params["kubernetes_version"] = self.cluster_version
         cluster_params["agent_pool_profiles"] = self.node_pools

--- a/python-lib/dku_azure/utils.py
+++ b/python-lib/dku_azure/utils.py
@@ -88,3 +88,17 @@ def get_host_network(credentials=None, resource_group=None, connection_info=None
     logging.info("VNET: {}".format(vnet))
     logging.info("SUBNET ID: {}".format(subnet_id))
     return vnet, subnet_id
+
+def patch_kube_config_with_aad(kube_config_string, authentication_mode, identity_label):
+    # determine which is the authentication mode
+    # depending on the authentication mode, the derivation command kubelogin options will be different
+    # 
+    # SERVICE-PRINCIPAL
+    # kubelogin get-token -l msi --server-id 6dae42f8-4368-4678-94ff-3960e28e3630 --identity-resource-id /subscriptions/8c59bf15-b4a9-4398-a354-d2a4e7d60e2a/resourcegroups/jcasoli-fm/providers/Microsoft.ManagedIdentity/userAssignedIdentities/dss-id-jcasoli
+    # USER-ASSIGNED
+    # kubelogin get-token -l msi --server-id 6dae42f8-4368-4678-94ff-3960e28e3630 --client-id de4cab2c-359c-4970-8032-89bee12a7d31
+    # DEFAULT
+    # kubelogin get-token -l msi --server-id 6dae42f8-4368-4678-94ff-3960e28e3630
+    # 
+    pass
+

--- a/python-lib/dku_azure/utils.py
+++ b/python-lib/dku_azure/utils.py
@@ -1,5 +1,5 @@
 import requests
-import json
+import yaml
 import logging
 
 from msrestazure.azure_exceptions import CloudError
@@ -90,6 +90,36 @@ def get_host_network(credentials=None, resource_group=None, connection_info=None
     return vnet, subnet_id
 
 def patch_kube_config_with_aad(kube_config_string, authentication_mode, identity_label):
+    kube_config = yaml.safe_load(kube_config_string)
+
+    kubelogin_command_options = ['get-token', '--login', 'msi', '--server-id', '6dae42f8-4368-4678-94ff-3960e28e3630']
+
+    additional_options = []
+    if authentication_mode == 'service-principal':
+        additional_options = ['--identity-resource-id', identity_label]
+    elif authentication_mode == 'user-assigned':
+        if identity_label.startswith("/"):
+            additional_options = ['--identity-resource-id', identity_label]
+        else:
+            additional_options = ['--client-id', identity_label]
+    
+    kubelogin_command_options = kubelogin_command_options + additional_options
+
+    kube_config_user = {
+        'name': kube_config['contexts'][0]['context']['user'],
+        'user': {
+            'exec': {
+                'apiVersion': 'client.authentication.k8s.io/v1beta1',
+                'command': 'kubelogin',
+                'args': kubelogin_command_options
+            }
+        }
+    }
+    
+    kube_config['users'] = [kube_config_user]
+
+    return kube_config
+
     # determine which is the authentication mode
     # depending on the authentication mode, the derivation command kubelogin options will be different
     # 
@@ -99,6 +129,4 @@ def patch_kube_config_with_aad(kube_config_string, authentication_mode, identity
     # kubelogin get-token -l msi --server-id 6dae42f8-4368-4678-94ff-3960e28e3630 --client-id de4cab2c-359c-4970-8032-89bee12a7d31
     # DEFAULT
     # kubelogin get-token -l msi --server-id 6dae42f8-4368-4678-94ff-3960e28e3630
-    # 
-    pass
 


### PR DESCRIPTION
State of this PR :
## It is paused
Starting with kubectl 1.26, cloud-dependent methods of authenticating (used by aks and gke) where deprecated. We did the transition for gke, and though that it was needed for aks, but, as it turns out, everything still seems to be working fine (tested with plugin version 1.2.0, using kubectl 1.26 creating a k8s cluster at version 1.26.0)
So, for now, this developpement is stalled.

## How auth currently works
We create a `kube_config` file, with at least the following section:
```
users:
- name: clusterAdmin_jcasoli-fm_jcasoli-aks
  user:
    client-certificate-data: LS0tLS1CRUdJTiBSU0EgU<-SomeLongBase64EncodedCert==
    client-key-data: LS0tLS1CRUdJTiBSU0EgU<-SomeLongBase64EncodedKey==
    token: cm0xpg7siubjx<-SomeToken
```
in practice, this means we authenticate using a (probably derived only once) given token. The associated identity is `clusterAdmin`, and we create (or maybe it already exists ?) a clusterrolebinding on the cluster with full rights:
```
> kubectl describe clusterrolebinding aks-cluster-admin-binding
Name:         aks-cluster-admin-binding
Labels:       addonmanager.kubernetes.io/mode=Reconcile
              kubernetes.io/cluster-service=true
Annotations:  <none>
Role:
  Kind:  ClusterRole
  Name:  cluster-admin
Subjects:
  Kind  Name          Namespace
  ----  ----          ---------
  User  clusterAdmin
  User  clusterUser
```

## What this PR changes
The `kube_config` is changed to look like this :
```
users:
- name: clusterAdmin_jcasoli-fm_jcasoli-aks
  user:
    exec:
      apiVersion: client.authentication.k8s.io/v1beta1
      args:
      - get-token
      - --login
      - msi
      - --server-id
      - 6dae42f8-4368-4678-94ff-3960e28e3630
      command: kubelogin
```
Meaning that we are going to use `kubelogin` to fetch a token. Note that there is several ways to identify oneself to get this token (dentity-resource-id, client-id, etc...), but the gist of it is that we are going to use an IAM identity, most probably the one set-up by DCS. I will be refered to a `dss-id-jcasoli`.
(as a aside `6dae42f8-4368-4678-94ff-3960e28e3630` is a hard-coded azure constant, it just means ~"aks service")
Note that, for kubelogin to work with Azure identites, we must setup our cluster to use `Azure AD authentication`. This is automatically set-up at the cluster creation by the plugin.
![image](https://user-images.githubusercontent.com/91876294/224984591-cc2d0739-be61-4394-b87e-5e2f9a7b784b.png)
The token we get is an Oauth token, granted to `dss-id-jcasoli`. <= very important
This token will be handled by aks control plane, but there is two possibility here:
1) It is handled by the k8s "standard" control plane directly. This correspond to the `Kubernetes RBAC` option :
![image](https://user-images.githubusercontent.com/91876294/224985161-655a6646-8596-4a5d-bc05-e30a1a2edd32.png)
2) It is handled by azure IAM, which then will send back an authorisation token to be used by k8s, still to the name of `dss-id-jcasoli`. This is the `Azure RBAC` option :
![image](https://user-images.githubusercontent.com/91876294/224985514-d4ba7f48-aa33-44f8-895e-3037af78a32c.png)

Both options have issues, which we don't know how to handle automatically for now. (the following are from memory, some of it may be slightly incorrect)
1) If we use `Kubernetes RBAC`, the k8s control plane will receive a token that is valid for user `dss-id-jcasoli`. However, it does not know this user, and we hence have to add it / add a corresponding clusterbindingrole. This could be done using aks cli, but, at that moment, the only iam identity we have is `dss-id-jcasoli`, which lacks enough rights to create the `clusterbindingrole`
2) If we use `Azure RBAC`, we encounter mostly the same issue, but with the additional indirection of Azure AD.

Indeed, DCS' doc says that `dss-id-jcasoli` should be a `Contributor` of the k8s Cluster (actually of the whole ressource group), which seems to be equivalent to giving hime the `Azure Kubernetes Service Contributor Role` rights, while we probably would need `Azure Kubernetes Service RBAC Admin`


