### PR TITLE
[AKS] Adding support for autoscaling in resize cluster macro

### DIFF
--- a/python-runnables/resize-node-pool/runnable.json
+++ b/python-runnables/resize-node-pool/runnable.json
@@ -29,9 +29,9 @@
         },
         {
             "name": "autoScaling",
-            "label": "Enable auto scaling",
+            "label": "Enable nodes auto scaling",
             "type": "BOOLEAN",
-            "description": "Whether the cluster's number of nodes should be automatically scaling",
+            "description": "Whether the cluster's number of nodes should automatically scale with the workload.",
             "mandatory": true,
             "defaultValue": false
         },
@@ -40,7 +40,6 @@
             "label": "Minimum number of nodes",
             "type": "INT",
             "mandatory": true,
-            "minI": 0,
             "defaultValue": 1,
             "visibilityCondition": "model.autoScaling"
         },
@@ -49,7 +48,6 @@
             "label": "Maximum number of nodes",
             "type": "INT",
             "mandatory": true,
-            "minI": 0,
             "defaultValue": 5,
             "visibilityCondition": "model.autoScaling"
         },

--- a/python-runnables/resize-node-pool/runnable.json
+++ b/python-runnables/resize-node-pool/runnable.json
@@ -40,6 +40,7 @@
             "label": "Minimum number of nodes",
             "type": "INT",
             "mandatory": true,
+            "minI": 0,
             "defaultValue": 1,
             "visibilityCondition": "model.autoScaling"
         },
@@ -48,6 +49,7 @@
             "label": "Maximum number of nodes",
             "type": "INT",
             "mandatory": true,
+            "minI": 1,
             "defaultValue": 5,
             "visibilityCondition": "model.autoScaling"
         },

--- a/python-runnables/resize-node-pool/runnable.json
+++ b/python-runnables/resize-node-pool/runnable.json
@@ -45,6 +45,13 @@
             "visibilityCondition": "model.autoScaling"
         },
         {
+            "name": "numNodes",
+            "label": "Number of nodes",
+            "type": "INT",
+            "minI": 0,
+            "mandatory": true
+        },
+        {
             "name": "maxNumNodes",
             "label": "Maximum number of nodes",
             "type": "INT",
@@ -52,13 +59,6 @@
             "minI": 1,
             "defaultValue": 5,
             "visibilityCondition": "model.autoScaling"
-        },
-        {
-            "name": "numNodes",
-            "label": "Number of nodes",
-            "type": "INT",
-            "mandatory": true,
-            "visibilityCondition": "!model.autoScaling"
         },
         {
             "name": "nodePoolId",

--- a/python-runnables/resize-node-pool/runnable.json
+++ b/python-runnables/resize-node-pool/runnable.json
@@ -45,13 +45,6 @@
             "visibilityCondition": "model.autoScaling"
         },
         {
-            "name": "numNodes",
-            "label": "Number of nodes",
-            "type": "INT",
-            "minI": 0,
-            "mandatory": true
-        },
-        {
             "name": "maxNumNodes",
             "label": "Maximum number of nodes",
             "type": "INT",
@@ -59,6 +52,14 @@
             "minI": 1,
             "defaultValue": 5,
             "visibilityCondition": "model.autoScaling"
+        },
+        {
+            "name": "numNodes",
+            "label": "Number of nodes",
+            "type": "INT",
+            "mandatory": true,
+            "minI": 0,
+            "visibilityCondition": "!model.autoScaling"
         },
         {
             "name": "nodePoolId",

--- a/python-runnables/resize-node-pool/runnable.json
+++ b/python-runnables/resize-node-pool/runnable.json
@@ -18,7 +18,7 @@
     "macroRoles": [
         { "type":"CLUSTER", "targetParamsKey":"clusterId", "limitToSamePlugin":true }
     ],
-    
+
     "params": [
         {
             "name": "clusterId",
@@ -28,10 +28,35 @@
             "mandatory": true
         },
         {
+            "name": "nodesAutoscaling",
+            "label": "Enable Autoscaling",
+            "type": "BOOLEAN",
+            "description": "Whether the cluster's number of nodes should be autoscaling",
+            "mandatory": true,
+            "defaultValue": false
+        },
+        {
+            "name": "minNumNodes",
+            "label": "Minimum number of nodes",
+            "type": "INT",
+            "mandatory": true,
+            "defaultValue": 1,
+            "visibilityCondition": "model.nodesAutoscaling"
+        },
+        {
+            "name": "maxNumNodes",
+            "label": "Maximum number of nodes",
+            "type": "INT",
+            "mandatory": true,
+            "defaultValue": 5,
+            "visibilityCondition": "model.nodesAutoscaling"
+        },
+        {
             "name": "numNodes",
             "label": "Number of nodes",
             "type": "INT",
-            "mandatory": true
+            "mandatory": true,
+            "visibilityCondition": "!model.nodesAutoscaling"
         },
         {
             "name": "nodePoolId",

--- a/python-runnables/resize-node-pool/runnable.json
+++ b/python-runnables/resize-node-pool/runnable.json
@@ -28,10 +28,10 @@
             "mandatory": true
         },
         {
-            "name": "nodesAutoscaling",
-            "label": "Enable Autoscaling",
+            "name": "autoScaling",
+            "label": "Enable auto scaling",
             "type": "BOOLEAN",
-            "description": "Whether the cluster's number of nodes should be autoscaling",
+            "description": "Whether the cluster's number of nodes should be automatically scaling",
             "mandatory": true,
             "defaultValue": false
         },
@@ -41,7 +41,7 @@
             "type": "INT",
             "mandatory": true,
             "defaultValue": 1,
-            "visibilityCondition": "model.nodesAutoscaling"
+            "visibilityCondition": "model.autoScaling"
         },
         {
             "name": "maxNumNodes",
@@ -49,14 +49,14 @@
             "type": "INT",
             "mandatory": true,
             "defaultValue": 5,
-            "visibilityCondition": "model.nodesAutoscaling"
+            "visibilityCondition": "model.autoScaling"
         },
         {
             "name": "numNodes",
             "label": "Number of nodes",
             "type": "INT",
             "mandatory": true,
-            "visibilityCondition": "!model.nodesAutoscaling"
+            "visibilityCondition": "!model.autoScaling"
         },
         {
             "name": "nodePoolId",

--- a/python-runnables/resize-node-pool/runnable.json
+++ b/python-runnables/resize-node-pool/runnable.json
@@ -29,7 +29,7 @@
         },
         {
             "name": "autoScaling",
-            "label": "Enable nodes auto scaling",
+            "label": "Enable nodes autoscaling",
             "type": "BOOLEAN",
             "description": "Whether the cluster's number of nodes should automatically scale with the workload.",
             "mandatory": true,

--- a/python-runnables/resize-node-pool/runnable.json
+++ b/python-runnables/resize-node-pool/runnable.json
@@ -40,6 +40,7 @@
             "label": "Minimum number of nodes",
             "type": "INT",
             "mandatory": true,
+            "minI": 0,
             "defaultValue": 1,
             "visibilityCondition": "model.autoScaling"
         },
@@ -48,6 +49,7 @@
             "label": "Maximum number of nodes",
             "type": "INT",
             "mandatory": true,
+            "minI": 0,
             "defaultValue": 5,
             "visibilityCondition": "model.autoScaling"
         },

--- a/python-runnables/resize-node-pool/runnable.py
+++ b/python-runnables/resize-node-pool/runnable.py
@@ -69,6 +69,8 @@ class MyRunnable(Runnable):
                 return '<pre class="debug">Node pool %s deleted</pre>' % node_pool_id
             else:
                 node_pool.count = desired_count
+                node_pool.min_count = None
+                node_pool.max_count = None
                 logging.info("Waiting for cluster resize")
 
         def do_update():

--- a/python-runnables/resize-node-pool/runnable.py
+++ b/python-runnables/resize-node-pool/runnable.py
@@ -48,17 +48,17 @@ class MyRunnable(Runnable):
             max_nodes = self.config['maxNumNodes']
             initial_node_count = self.config['numNodes']
             if min_nodes is None:
-                raise Exception("Cannot make auto scalable cluster with no minimum number of nodes.")
+                raise Exception("Cannot make autoscalable cluster with no minimum number of nodes.")
             elif max_nodes is None:
-                raise Exception("Cannot make auto scalable cluster with no maximum number of nodes.")
+                raise Exception("Cannot make autoscalable cluster with no maximum number of nodes.")
             elif initial_node_count is None or initial_node_count < min_nodes or initial_node_count > max_nodes:
                 raise Exception("The initial number of nodes must be set and between the min and max number of nodes bounds ([%s %s])."
                                 % (min_nodes, max_nodes))
             elif min_nodes > max_nodes:
-                raise Exception("Cannot make auto scalable cluster with a max number of nodes (%s) less than its min number of nodes (%s)."
+                raise Exception("Cannot make autoscalable cluster with a max number of nodes (%s) less than its min number of nodes (%s)."
                                 % (max_nodes, min_nodes))
             else:
-                logging.info("Resizing cluster to auto scale with %s min nodes and %s max nodes and an initial node count of %s."
+                logging.info("Resizing cluster to autoscale with %s min nodes and %s max nodes and an initial node count of %s."
                              % (min_nodes, max_nodes, initial_node_count))
                 node_pool.enable_auto_scaling = autoscaling_enabled
                 node_pool.min_count = min_nodes

--- a/python-runnables/resize-node-pool/runnable.py
+++ b/python-runnables/resize-node-pool/runnable.py
@@ -57,8 +57,8 @@ class MyRunnable(Runnable):
                 raise Exception("Cannot make auto scalable cluster with a maximum number of nodes less than its "
                                 "minimum number of nodes.")
             else:
-                logging.info("Resizing cluster to auto scale with %s min nodes and %s max nodes"
-                             % (min_nodes, max_nodes))
+                logging.info("Resizing cluster to auto scale with %s min nodes and %s max nodes and an initial node count of %s"
+                             % (min_nodes, max_nodes, initial_node_count))
                 node_pool.enable_auto_scaling = autoscaling_enabled
                 node_pool.min_count = min_nodes
                 node_pool.count = initial_node_count

--- a/python-runnables/resize-node-pool/runnable.py
+++ b/python-runnables/resize-node-pool/runnable.py
@@ -42,8 +42,8 @@ class MyRunnable(Runnable):
         node_pool_id = node_pool.name
         logging.info("Node pool selected is %s " % node_pool_id)
 
-        auto_scaling_enabled = self.config['autoScaling']
-        if auto_scaling_enabled:
+        autoscaling_enabled = self.config['autoScaling']
+        if autoscaling_enabled:
             min_nodes = self.config['minNumNodes']
             max_nodes = self.config['maxNumNodes']
             if min_nodes is None:
@@ -56,7 +56,7 @@ class MyRunnable(Runnable):
             else:
                 logging.info("Resizing cluster to auto scale with %s min nodes and %s max nodes"
                              % (min_nodes, max_nodes))
-                node_pool.enable_cluster_autoscaler = auto_scaling_enabled
+                node_pool.enable_cluster_autoscaling = autoscaling_enabled
                 node_pool.min_count = min_nodes
                 node_pool.max_count = max_nodes
         else:

--- a/python-runnables/resize-node-pool/runnable.py
+++ b/python-runnables/resize-node-pool/runnable.py
@@ -56,9 +56,9 @@ class MyRunnable(Runnable):
             else:
                 logging.info("Resizing cluster to auto scale with %s min nodes and %s max nodes"
                              % (min_nodes, max_nodes))
-                node_pool.autoScaling = auto_scaling_enabled
-                node_pool.minNumNodes = min_nodes
-                node_pool.maxNumNodes = max_nodes
+                node_pool.enable_cluster_autoscaler = auto_scaling_enabled
+                node_pool.min_count = min_nodes
+                node_pool.max_count = max_nodes
         else:
             desired_count = self.config['numNodes']
             logging.info("Resize to %s" % desired_count)

--- a/python-runnables/resize-node-pool/runnable.py
+++ b/python-runnables/resize-node-pool/runnable.py
@@ -42,8 +42,8 @@ class MyRunnable(Runnable):
         node_pool_id = node_pool.name
         logging.info("Node pool selected is %s " % node_pool_id)
 
-        enable_autoscaling = self.config['nodesAutoscaling']
-        if enable_autoscaling:
+        auto_scaling_enabled = self.config['autoScaling']
+        if auto_scaling_enabled:
             min_nodes = self.config['minNumNodes']
             max_nodes = self.config['maxNumNodes']
             if min_nodes is None:
@@ -56,7 +56,7 @@ class MyRunnable(Runnable):
             else:
                 logging.info("Resizing cluster to auto scale with %s min nodes and %s max nodes"
                              % (min_nodes, max_nodes))
-                node_pool.autoScaling = enable_autoscaling
+                node_pool.autoScaling = auto_scaling_enabled
                 node_pool.minNumNodes = min_nodes
                 node_pool.maxNumNodes = max_nodes
         else:

--- a/python-runnables/resize-node-pool/runnable.py
+++ b/python-runnables/resize-node-pool/runnable.py
@@ -52,12 +52,13 @@ class MyRunnable(Runnable):
             elif max_nodes is None:
                 raise Exception("Cannot make auto scalable cluster with no maximum number of nodes.")
             elif initial_node_count is None or initial_node_count < min_nodes or initial_node_count > max_nodes:
-                initial_node_count = min_nodes
+                raise Exception("The initial number of nodes must be set and between the min and max number of nodes bounds ([%s %s])."
+                                % (min_nodes, max_nodes))
             elif min_nodes > max_nodes:
-                raise Exception("Cannot make auto scalable cluster with a maximum number of nodes less than its "
-                                "minimum number of nodes.")
+                raise Exception("Cannot make auto scalable cluster with a max number of nodes (%s) less than its min number of nodes (%s)."
+                                % (max_nodes, min_nodes))
             else:
-                logging.info("Resizing cluster to auto scale with %s min nodes and %s max nodes and an initial node count of %s"
+                logging.info("Resizing cluster to auto scale with %s min nodes and %s max nodes and an initial node count of %s."
                              % (min_nodes, max_nodes, initial_node_count))
                 node_pool.enable_auto_scaling = autoscaling_enabled
                 node_pool.min_count = min_nodes

--- a/python-runnables/resize-node-pool/runnable.py
+++ b/python-runnables/resize-node-pool/runnable.py
@@ -46,10 +46,13 @@ class MyRunnable(Runnable):
         if autoscaling_enabled:
             min_nodes = self.config['minNumNodes']
             max_nodes = self.config['maxNumNodes']
+            initial_node_count = self.config['numNodes']
             if min_nodes is None:
                 raise Exception("Cannot make auto scalable cluster with no minimum number of nodes.")
             elif max_nodes is None:
                 raise Exception("Cannot make auto scalable cluster with no maximum number of nodes.")
+            elif initial_node_count is None or initial_node_count < min_nodes or initial_node_count > max_nodes:
+                initial_node_count = min_nodes
             elif min_nodes > max_nodes:
                 raise Exception("Cannot make auto scalable cluster with a maximum number of nodes less than its "
                                 "minimum number of nodes.")
@@ -58,7 +61,10 @@ class MyRunnable(Runnable):
                              % (min_nodes, max_nodes))
                 node_pool.enable_auto_scaling = autoscaling_enabled
                 node_pool.min_count = min_nodes
+                node_pool.count = initial_node_count
                 node_pool.max_count = max_nodes
+                # This is used in the autoscaling node pool allocation, is it necessary?
+                node_pool.type_properties_type = "VirtualMachineScaleSets"
         else:
             desired_count = self.config['numNodes']
             logging.info("Resize to %s" % desired_count)

--- a/python-runnables/resize-node-pool/runnable.py
+++ b/python-runnables/resize-node-pool/runnable.py
@@ -43,6 +43,7 @@ class MyRunnable(Runnable):
         logging.info("Node pool selected is %s " % node_pool_id)
 
         autoscaling_enabled = self.config['autoScaling']
+        node_pool.enable_auto_scaling = autoscaling_enabled
         if autoscaling_enabled:
             min_nodes = self.config['minNumNodes']
             max_nodes = self.config['maxNumNodes']
@@ -60,7 +61,6 @@ class MyRunnable(Runnable):
             else:
                 logging.info("Resizing cluster to autoscale with %s min nodes and %s max nodes and an initial node count of %s."
                              % (min_nodes, max_nodes, initial_node_count))
-                node_pool.enable_auto_scaling = autoscaling_enabled
                 node_pool.min_count = min_nodes
                 node_pool.count = initial_node_count
                 node_pool.max_count = max_nodes

--- a/python-runnables/resize-node-pool/runnable.py
+++ b/python-runnables/resize-node-pool/runnable.py
@@ -56,7 +56,7 @@ class MyRunnable(Runnable):
             else:
                 logging.info("Resizing cluster to auto scale with %s min nodes and %s max nodes"
                              % (min_nodes, max_nodes))
-                node_pool.enable_cluster_autoscaling = autoscaling_enabled
+                node_pool.enable_auto_scaling = autoscaling_enabled
                 node_pool.min_count = min_nodes
                 node_pool.max_count = max_nodes
         else:

--- a/python-runnables/resize-node-pool/runnable.py
+++ b/python-runnables/resize-node-pool/runnable.py
@@ -47,25 +47,14 @@ class MyRunnable(Runnable):
         if autoscaling_enabled:
             min_nodes = self.config['minNumNodes']
             max_nodes = self.config['maxNumNodes']
-            initial_node_count = self.config['numNodes']
-            if min_nodes is None:
-                raise Exception("Cannot make autoscalable cluster with no minimum number of nodes.")
-            elif max_nodes is None:
-                raise Exception("Cannot make autoscalable cluster with no maximum number of nodes.")
-            elif initial_node_count is None or initial_node_count < min_nodes or initial_node_count > max_nodes:
-                raise Exception("The initial number of nodes must be set and between the min and max number of nodes bounds ([%s %s])."
-                                % (min_nodes, max_nodes))
-            elif min_nodes > max_nodes:
-                raise Exception("Cannot make autoscalable cluster with a max number of nodes (%s) less than its min number of nodes (%s)."
+            if min_nodes > max_nodes:
+                raise Exception("Cannot resize autoscalable cluster with a max number of nodes (%s) less than its min number of nodes (%s)."
                                 % (max_nodes, min_nodes))
             else:
-                logging.info("Resizing cluster to autoscale with %s min nodes and %s max nodes and an initial node count of %s."
-                             % (min_nodes, max_nodes, initial_node_count))
+                logging.info("Resizing cluster to autoscale with %s min nodes and %s max nodes."
+                             % (min_nodes, max_nodes))
                 node_pool.min_count = min_nodes
-                node_pool.count = initial_node_count
                 node_pool.max_count = max_nodes
-                # This is used in the autoscaling node pool allocation, is it necessary?
-                node_pool.type_properties_type = "VirtualMachineScaleSets"
         else:
             desired_count = self.config['numNodes']
             logging.info("Resize to %s" % desired_count)


### PR DESCRIPTION
[sc-154137]

For Azure Kubernetes clusters, when resizing the cluster's node pool, it is not possible to resize to an autoscaled number of nodes.
This PR aims to add this capability by letting the user choose to make the node pool autoscalable and min/max boundaries. It also lets the user change (back) to a static number of nodes from an autoscalable node pool.