### PR TITLE
Fix vnet sanity check for adding a new node pool

### DIFF
--- a/python-runnables/add-node-pool/runnable.py
+++ b/python-runnables/add-node-pool/runnable.py
@@ -55,18 +55,21 @@ class MyRunnable(Runnable):
         # Sanity check for node pools
         node_pool_vnets = set()
         for node_pool in node_pools:
-            nodepool_vnet = node_pool.vnet_subnet_id.split("/")[-3]
+            # Extract the full resource id of the vnet from the subnet id
+            nodepool_vnet = '/'.join(node_pool.vnet_subnet_id.split('/')[:-2])
             node_pool_vnets.add(nodepool_vnet)
         if len(node_pool_vnets) > 0:
             node_pool_vnet = node_pool_config.get("vnet", None)
             node_pool_subnet = node_pool_config.get("subnet", None)
-            node_pool_vnet, _ = node_pool_builder.resolve_network(inherit_from_host=node_pool_config.get("useSameNetworkAsDSSHost"),
+            _, node_pool_subnet = node_pool_builder.resolve_network(inherit_from_host=node_pool_config.get("useSameNetworkAsDSSHost"),
                                            cluster_vnet=node_pool_vnet,
                                            cluster_subnet=node_pool_subnet,
                                            connection_info=connection_info,
                                            credentials=credentials,
                                            resource_group=resource_group,
                                            dss_host_resource_group=dss_host_resource_group)
+            # Extract the full resource id of the vnet from the subnet id
+            node_pool_vnet = '/'.join(node_pool_subnet.split('/')[:-2])
             if not node_pool_vnet in node_pool_vnets:
                 node_pool_vnets.add(node_pool_vnet)
                 raise Exception("Node pools must all share the same vnet. Current node pools configuration yields vnets {}.".format(",".join(node_pool_vnets)))


### PR DESCRIPTION
# Description

When adding a new node pool to an AKS cluster, we allow three ways to specify the networking settings:
1. Inherit from host DSS
2. Use the vnet name
3. Use the vnet full resource id

The last case fails the sanity check that verifies that we deploy the node pools in the same vnet. This is because we compare the vnet name (resolved from the agent_pool subnetId) with the vnet full resource id (specified in the config).

# Proposed fix:
Always compare full resource ids. That way, it will always ensure that we are adding to the same vnet instead of a vnet of the same name which could be actually a different vnet in a different resource group. Also it fixes the sanity check for when the user enters the full resource id for the vnet.

# Repro steps:
- [ ] Deploy DSS
- [ ] Create cluster
- [ ] Go to `Actions` > `Add Node Pool`
- [ ] In the networking section, enter the full resource id of your vnet and the name of the subnet:
<img width="618" alt="image" src="https://github.com/dataiku/dss-plugin-aks-clusters/assets/1655134/8ff49110-ca17-47da-af89-36a854f175e6">

- [ ] Click on `Run Macro`

This should fail saying that all node pools must share the same vnet.

# Verification:
When verifying the fix, please also ensure that the other networking settings work:
- [ ] Inherit settings from DSS
- [ ] Use the vnet name only

[sc-173574]