### PR TITLE
Fix AKS cluster start

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 3.0.2 - Bugfix release
+- Fixing resolution of Azure API version
+
 ## Version 3.0.1 - Bugfix release
 - Fixing support for taints for GPU enabled node pools
 

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -1,7 +1,7 @@
 azure-identity<1.18
 azure-mgmt-authorization==2.0.0
 azure-mgmt-compute==23.1.0
-azure-mgmt-containerservice>=16.4.0
+azure-mgmt-containerservice>=16.4.0,<39.0.0
 azure-mgmt-resource==20.0.0
 azure-mgmt-msi==6.0.0b1
 ipaddress==1.0.23

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "aks-clusters",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "meta": {
         "label": "AKS clusters",
         "description": "Interact with or create Microsoft Azure Kubernetes Service clusters",


### PR DESCRIPTION
## Context
The package `azure-mgmt-containerservice` was updated to 39.0.0 which is a huge change that removes and renames a lot of stuff.

We are going to pin the package for now and eventually upgrade it. But that'll require very thorough testing so for mitigation purposes, we pin the version and people facing the issue can do the same on the code environment (+rebuild it).

## Repro steps:
- Provision Azure DSS instance with container support (via FM instance template)
- Create a cluster
- Start the cluster &rArr; Failure ❌

## Testing steps:
- Update plugin (rebuild code env)
- Start the cluster &rArr; Success ✅