### PR TITLE
Support AKS access mode for cluster user kubeconfig

### DIFF
--- a/python-clusters/attach-aks-cluster/cluster.json
+++ b/python-clusters/attach-aks-cluster/cluster.json
@@ -4,7 +4,7 @@
         "description" : "Attach to a running AKS cluster",
         "icon" : "icon-puzzle-piece"
     },
-    
+    "paramsPythonSetup": "aks_access_modes.py",
     "architecture" : "KUBERNETES",
 
     "params": [
@@ -21,6 +21,16 @@
             "type": "PRESET",
             "parameterSetId" : "connection-info-v2",
             "mandatory" : true
+        },
+        {
+            "name": "aksAccessMode",
+            "label": "AKS access mode",
+            "description": "Choose how DSS should access this AKS cluster. Depending on the mode, DSS will request the corresponding AKS access configuration.",
+            "type": "SELECT",
+            "getChoicesFromPython": true,
+            "disableAutoReload": true,
+            "mandatory": true,
+            "defaultValue": "admin"
         },
         {
             "name": "cluster",

--- a/python-clusters/attach-aks-cluster/cluster.json
+++ b/python-clusters/attach-aks-cluster/cluster.json
@@ -30,7 +30,7 @@
             "getChoicesFromPython": true,
             "disableAutoReload": true,
             "mandatory": true,
-            "defaultValue": "admin"
+            "defaultValue": "cluster-admin"
         },
         {
             "name": "cluster",

--- a/python-clusters/attach-aks-cluster/cluster.py
+++ b/python-clusters/attach-aks-cluster/cluster.py
@@ -3,7 +3,7 @@ from dataiku.cluster import Cluster
 
 from azure.mgmt.containerservice import ContainerServiceClient
 from dku_utils.access import _is_none_or_blank
-from dku_utils.cluster import make_overrides
+from dku_utils.cluster import make_overrides, fetch_cluster_kubeconfig, get_aks_access_mode
 from dku_azure.auth import get_credentials_from_connection_info, get_credentials_from_connection_infoV2
 from dku_azure.utils import run_and_process_cloud_error, get_instance_metadata, get_subscription_id
 
@@ -45,12 +45,9 @@ class MyCluster(Cluster):
 
         clusters_client = ContainerServiceClient(credentials, subscription_id)
 
-        # Get kubeconfig 
-        logging.info("Fetching kubeconfig for cluster %s in %s", cluster_name, resource_group)
-        def do_fetch():
-            return clusters_client.managed_clusters.list_cluster_admin_credentials(resource_group, cluster_name)
-        get_credentials_result = run_and_process_cloud_error(do_fetch)
-        kube_config_content = get_credentials_result.kubeconfigs[0].value.decode('utf8')
+        # Get kubeconfig
+        aks_access_mode = get_aks_access_mode(self.config)
+        kube_config_content = fetch_cluster_kubeconfig(clusters_client, resource_group, cluster_name, aks_access_mode)
         kube_config_path = os.path.join(os.getcwd(), 'kube_config')
         with open(kube_config_path, 'w') as f:
             f.write(kube_config_content)
@@ -65,4 +62,3 @@ class MyCluster(Cluster):
 
     def stop(self, data):
         pass
-

--- a/python-clusters/create-aks-cluster/cluster.json
+++ b/python-clusters/create-aks-cluster/cluster.json
@@ -4,6 +4,7 @@
         "description": "Create AKS clusters",
         "icon": "icon-puzzle-piece"
     },
+    "paramsPythonSetup": "aks_access_modes.py",
     "architecture": "KUBERNETES",
     "params": [
         {
@@ -203,6 +204,16 @@
             "description": "Additional settings for the cluster creation call, as JSON",
             "type": "TEXTAREA",
             "mandatory": false
+        },
+        {
+            "name": "aksAccessMode",
+            "label": "AKS access mode",
+            "description": "Choose how DSS should access this AKS cluster. Depending on the mode, DSS will request the corresponding AKS access configuration.",
+            "type": "SELECT",
+            "getChoicesFromPython": true,
+            "disableAutoReload": true,
+            "mandatory": true,
+            "defaultValue": "admin"
         },
         {
             "name": "s-legacy",

--- a/python-clusters/create-aks-cluster/cluster.json
+++ b/python-clusters/create-aks-cluster/cluster.json
@@ -213,7 +213,7 @@
             "getChoicesFromPython": true,
             "disableAutoReload": true,
             "mandatory": true,
-            "defaultValue": "admin"
+            "defaultValue": "cluster-admin"
         },
         {
             "name": "s-legacy",

--- a/python-clusters/create-aks-cluster/cluster.py
+++ b/python-clusters/create-aks-cluster/cluster.py
@@ -9,7 +9,7 @@ from azure.core.pipeline.policies import UserAgentPolicy
 from azure.core.exceptions import ResourceNotFoundError, HttpResponseError
 
 from dku_utils.access import _is_none_or_blank
-from dku_utils.cluster import make_overrides
+from dku_utils.cluster import make_overrides, fetch_cluster_kubeconfig, get_aks_access_mode
 from dku_utils.taints import Toleration
 from dku_kube.nvidia_utils import add_gpu_driver_if_needed
 from dku_azure.auth import get_credentials_from_connection_info, get_credentials_from_connection_infoV2
@@ -406,11 +406,9 @@ class MyCluster(Cluster):
                         "role_assignment": vnet_role_assignment.as_dict(),
                     })
 
-        logging.info("Fetching kubeconfig for cluster {} in {}...".format(self.cluster_name, resource_group))
-        def do_fetch():
-            return clusters_client.managed_clusters.list_cluster_admin_credentials(resource_group, self.cluster_name)
-        get_credentials_result = run_and_process_cloud_error(do_fetch)
-        kube_config_content = get_credentials_result.kubeconfigs[0].value.decode("utf8")
+        aks_access_mode = get_aks_access_mode(self.config)
+        kube_config_content = fetch_cluster_kubeconfig(clusters_client, resource_group, self.cluster_name, aks_access_mode)
+
         logging.info("Writing kubeconfig file...")
         kube_config_path = os.path.join(os.getcwd(), "kube_config")
         with open(kube_config_path, 'w') as f:

--- a/python-lib/dku_utils/aks_access.py
+++ b/python-lib/dku_utils/aks_access.py
@@ -1,10 +1,10 @@
-AKS_ACCESS_MODE_ADMIN = "admin"
+AKS_ACCESS_MODE_CLUSTER_ADMIN = "cluster-admin"
 AKS_ACCESS_MODE_CLUSTER_USER = "cluster-user"
 
-DEFAULT_AKS_ACCESS_MODE = AKS_ACCESS_MODE_ADMIN
+DEFAULT_AKS_ACCESS_MODE = AKS_ACCESS_MODE_CLUSTER_ADMIN
 AKS_ACCESS_MODE_CHOICES = [
-    {"value": AKS_ACCESS_MODE_ADMIN, "label": "Admin"},
-    {"value": AKS_ACCESS_MODE_CLUSTER_USER, "label": "Cluster user"},
+    {"value": AKS_ACCESS_MODE_CLUSTER_ADMIN, "label": "Cluster Admin"},
+    {"value": AKS_ACCESS_MODE_CLUSTER_USER, "label": "Cluster User"},
 ]
 AKS_ACCESS_MODES = {
     choice["value"] for choice in AKS_ACCESS_MODE_CHOICES

--- a/python-lib/dku_utils/aks_access.py
+++ b/python-lib/dku_utils/aks_access.py
@@ -1,0 +1,11 @@
+AKS_ACCESS_MODE_ADMIN = "admin"
+AKS_ACCESS_MODE_CLUSTER_USER = "cluster-user"
+
+DEFAULT_AKS_ACCESS_MODE = AKS_ACCESS_MODE_ADMIN
+AKS_ACCESS_MODE_CHOICES = [
+    {"value": AKS_ACCESS_MODE_ADMIN, "label": "Admin"},
+    {"value": AKS_ACCESS_MODE_CLUSTER_USER, "label": "Cluster user"},
+]
+AKS_ACCESS_MODES = {
+    choice["value"] for choice in AKS_ACCESS_MODE_CHOICES
+}

--- a/python-lib/dku_utils/cluster.py
+++ b/python-lib/dku_utils/cluster.py
@@ -3,7 +3,12 @@ import dataiku
 from azure.mgmt.containerservice import ContainerServiceClient
 from dataiku.core.intercom import backend_json_call
 from dku_azure.auth import get_credentials_from_connection_info, get_credentials_from_connection_infoV2
-from dku_azure.utils import get_subscription_id
+from dku_azure.utils import get_subscription_id, run_and_process_cloud_error
+from dku_utils.aks_access import (
+    AKS_ACCESS_MODE_CLUSTER_USER,
+    DEFAULT_AKS_ACCESS_MODE,
+    AKS_ACCESS_MODES,
+)
 from dku_utils.access import _is_none_or_blank
 
 
@@ -18,6 +23,28 @@ def make_overrides(config, kube_config, kube_config_path, acr_name=None):
     if acr_name is not None:
         container_settings['executionConfigsGenericOverrides']['repositoryURL'] = "{}.azurecr.io".format(acr_name)
     return {'container':container_settings}
+
+
+def get_aks_access_mode(config):
+    access_mode = config.get("aksAccessMode", DEFAULT_AKS_ACCESS_MODE)
+    if access_mode not in AKS_ACCESS_MODES:
+        logging.warning("Unknown AKS access mode %s, defaulting to %s", access_mode, DEFAULT_AKS_ACCESS_MODE)
+        return DEFAULT_AKS_ACCESS_MODE
+    return access_mode
+
+
+def fetch_cluster_kubeconfig(clusters_client, resource_group, cluster_name, aks_access_mode):
+    logging.info("Fetching kubeconfig for cluster %s in %s using AKS access mode %s", cluster_name, resource_group, aks_access_mode)
+
+    def do_fetch():
+        if aks_access_mode == AKS_ACCESS_MODE_CLUSTER_USER:
+            return clusters_client.managed_clusters.list_cluster_user_credentials(resource_group, cluster_name)
+        return clusters_client.managed_clusters.list_cluster_admin_credentials(resource_group, cluster_name)
+
+    get_credentials_result = run_and_process_cloud_error(do_fetch)
+    if len(get_credentials_result.kubeconfigs) == 0:
+        raise Exception("Azure did not return any kubeconfig for cluster %s in %s" % (cluster_name, resource_group))
+    return get_credentials_result.kubeconfigs[0].value.decode("utf8")
 
 
 def get_cluster_from_connection_info(config, plugin_config):

--- a/python-lib/dku_utils/cluster.py
+++ b/python-lib/dku_utils/cluster.py
@@ -28,8 +28,7 @@ def make_overrides(config, kube_config, kube_config_path, acr_name=None):
 def get_aks_access_mode(config):
     access_mode = config.get("aksAccessMode", DEFAULT_AKS_ACCESS_MODE)
     if access_mode not in AKS_ACCESS_MODES:
-        logging.warning("Unknown AKS access mode %s, defaulting to %s", access_mode, DEFAULT_AKS_ACCESS_MODE)
-        return DEFAULT_AKS_ACCESS_MODE
+        raise ValueError("Unknown AKS access mode %s, expected one of %s" % (access_mode, AKS_ACCESS_MODES))
     return access_mode
 
 

--- a/resource/aks_access_modes.py
+++ b/resource/aks_access_modes.py
@@ -1,0 +1,5 @@
+from dku_utils.aks_access import AKS_ACCESS_MODE_CHOICES
+
+
+def do(payload, config, plugin_config, inputs):
+    return {"choices": AKS_ACCESS_MODE_CHOICES}


### PR DESCRIPTION
**Summary**
This PR adds an `AKS access mode` option to AKS attach/create flows so DSS can request either:
- admin access
- cluster-user access

The goal is to avoid calling `Microsoft.ContainerService/managedClusters/listClusterAdminCredential/action` when customers only want user-level AKS access. This is useful in environments that alert on admin credential retrieval.

**Motivation**
Today the plugin always fetches admin kubeconfig:
- attach: fails in environments where the DSS identity is not allowed to call `listClusterAdminCredential`
- create: cluster provisioning can succeed, but the final attach fails on the same admin kubeconfig fetch

This PR makes that behavior explicit and configurable.

**What Changed**
- Added a shared AKS access mode definition used by both UI and runtime logic.
- Added `AKS access mode` to:
  - `Attach AKS cluster`
  - `Create AKS cluster`
- Supported modes in this PR:
  - `cluster admin`
  - `cluster user`
- Default remains `cluster admin` for backward compatibility.
- Both attach and create now route kubeconfig retrieval through the shared helper and select:
  - `list_cluster_admin_credentials(...)`
  - or `list_cluster_user_credentials(...)`

**Why the Label Is “AKS access mode”**
The new field is intentionally broader than “kubeconfig type” or “credential mode”.
It is meant to stay extensible if we later add a third mode for Microsoft Entra / app-based access without renaming the setting again.

**Extensibility**
The implementation is intentionally structured so we can later add an Entra-based mode, for example:
- `admin`
- `cluster user`
- `entra app` / `identity`

The shared access-mode definitions and central kubeconfig fetch helper are already separated so a future Entra flow can be added without reworking the cluster forms again.

**Test Plan**
Use one resource group variable and two separate user-assigned managed identities:
- one for the attach scenario
- one for the create scenario

Set up common variables:

```bash
SUB="8c59bf15-b4a9-4398-a354-d2a4e7d60e2a"
RG="<resource-group>"
DSS_VM_NAME="<dss-vm-name>"

AKS_NAME_ATTACH="clusteronly-attach"
AKS_NAME_CREATE="clusteronly-create"

ATTACH_MI_NAME="aks-attach-noadmincreds"
CREATE_MI_NAME="aks-create-noadmincreds"

az account set --subscription "$SUB"
```

Create the identities:

```bash
az identity create -g "$RG" -n "$ATTACH_MI_NAME"
az identity create -g "$RG" -n "$CREATE_MI_NAME"
```

Resolve their IDs:

```bash
ATTACH_MI_ID=$(az identity show -g "$RG" -n "$ATTACH_MI_NAME" --query id -o tsv)
ATTACH_MI_CLIENT_ID=$(az identity show -g "$RG" -n "$ATTACH_MI_NAME" --query clientId -o tsv)
ATTACH_MI_PRINCIPAL_ID=$(az identity show -g "$RG" -n "$ATTACH_MI_NAME" --query principalId -o tsv)

CREATE_MI_ID=$(az identity show -g "$RG" -n "$CREATE_MI_NAME" --query id -o tsv)
CREATE_MI_CLIENT_ID=$(az identity show -g "$RG" -n "$CREATE_MI_NAME" --query clientId -o tsv)
CREATE_MI_PRINCIPAL_ID=$(az identity show -g "$RG" -n "$CREATE_MI_NAME" --query principalId -o tsv)
```

Attach both identities to the DSS VM:

```bash
az vm identity assign -g "$RG" -n "$DSS_VM_NAME" --identities "$ATTACH_MI_ID" "$CREATE_MI_ID"
```

**Attach scenario**

Create a non-Entra AKS cluster with local accounts enabled and explicit networking so the node pool reports a real `vnetSubnetId`:

```bash
az aks create \
  -g "$RG" \
  -n "$AKS_NAME_ATTACH" \
  --node-count 1 \
  --generate-ssh-keys \
  --enable-managed-identity \
  --assign-identity "$ATTACH_MI_ID" \
  --network-plugin azure \
  --vnet-subnet-id "/subscriptions/$SUB/resourceGroups/$RG/providers/Microsoft.Network/virtualNetworks/valrutz-fm-vn/subnets/valrutz-fm-subnet1" \
  --service-cidr "10.240.0.0/16" \
  --dns-service-ip "10.240.0.10"
```

Grant the attach identity cluster-user kubeconfig access and node-pool management access without admin kubeconfig:

```bash
AKS_ATTACH_ID=$(az aks show -g "$RG" -n "$AKS_NAME_ATTACH" --query id -o tsv)

az role assignment create \
  --assignee "$ATTACH_MI_PRINCIPAL_ID" \
  --role "Azure Kubernetes Service Cluster User Role" \
  --scope "$AKS_ATTACH_ID"

az role assignment create \
  --assignee "$ATTACH_MI_PRINCIPAL_ID" \
  --role "AKS Node Pool Manager Without Admin Kubeconfig" \
  --scope "$AKS_ATTACH_ID"

az role assignment create \
  --assignee "$ATTACH_MI_PRINCIPAL_ID" \
  --role "Reader" \
  --scope "/subscriptions/$SUB/resourceGroups/$RG"
```

Verify no inherited broad role restores admin kubeconfig access:

```bash
az role assignment list \
  --assignee "$ATTACH_MI_PRINCIPAL_ID" \
  --scope "$AKS_ATTACH_ID" \
  --include-inherited \
  -o table
```

In DSS `Attach AKS cluster`, use:
- `Credentials > Identity type = User Assigned Managed Identity`
- `Credentials > User Assigned Managed Id = $ATTACH_MI_CLIENT_ID` or `$ATTACH_MI_ID`
- `Custom AKS cluster name = $AKS_NAME_ATTACH`

Expected results:
- `AKS access mode = admin` -> attach fails on `listClusterAdminCredential/action`
- `AKS access mode = cluster user` -> attach succeeds

Smoke-test after successful attach:
- inspect node pools
- add node pool
- resize node pool
- network test

**Create scenario**

Assign the create identity the AKS create/manage custom role and linked-resource roles:

```bash
az role assignment create \
  --assignee "$CREATE_MI_PRINCIPAL_ID" \
  --role "AKS Contributor Without Admin Kubeconfig" \
  --scope "/subscriptions/$SUB/resourceGroups/$RG"

az role assignment create \
  --assignee "$CREATE_MI_PRINCIPAL_ID" \
  --role "Reader" \
  --scope "/subscriptions/$SUB/resourceGroups/$RG"

az role assignment create \
  --assignee "$CREATE_MI_PRINCIPAL_ID" \
  --role "Network Contributor" \
  --scope "/subscriptions/$SUB/resourceGroups/$RG"

az role assignment create \
  --assignee "$CREATE_MI_PRINCIPAL_ID" \
  --role "Managed Identity Operator" \
  --scope "/subscriptions/$SUB/resourceGroups/$RG"

az role assignment create \
  --assignee "$CREATE_MI_PRINCIPAL_ID" \
  --role "Azure Kubernetes Service Cluster User Role" \
  --scope "/subscriptions/$SUB/resourceGroups/$RG"
```

Verify:

```bash
az role assignment list \
  --assignee "$CREATE_MI_PRINCIPAL_ID" \
  --scope "/subscriptions/$SUB/resourceGroups/$RG" \
  --include-inherited \
  -o table
```

In DSS `Create AKS cluster`, use:
- `Credentials > Identity type = User Assigned Managed Identity`
- `Credentials > User Assigned Managed Id = $CREATE_MI_CLIENT_ID` or `$CREATE_MI_ID`
- `Kubernetes Network Plugin = azure`
- `Service CIDR = 10.3.0.0/16`
- `DNS IP = 10.3.0.10`

Expected results:
- `AKS access mode = admin` -> cluster provisioning succeeds, final attach fails on `listClusterAdminCredential/action`, you may have to manually delete the cluster on the portal or via the CLI
- `AKS access mode = cluster user` -> cluster provisioning succeeds, final attach succeeds

Smoke-test after successful create:
- inspect node pools
- add node pool
- resize node pool
- network test

**Expected Outcome**
In the supported non-Entra, local-account-enabled scenario:
- `admin` mode reproduces the current failure when admin kubeconfig fetch is blocked
- `cluster user` mode succeeds
- post-attach and post-create behavior remains functionally equivalent for plugin operations
- the only meaningful Azure-side difference is:
  - `admin` -> `listClusterAdminCredential`
  - `cluster user` -> `listClusterUserCredential`