### PR TITLE
fix: [sc-301863] [AKS] Add node pool action is broken with "Automatic" mode

### DIFF
--- a/python-clusters/create-aks-cluster/cluster.py
+++ b/python-clusters/create-aks-cluster/cluster.py
@@ -14,7 +14,7 @@ from dku_utils.taints import Toleration
 from dku_kube.nvidia_utils import add_gpu_driver_if_needed
 from dku_azure.auth import get_credentials_from_connection_info, get_credentials_from_connection_infoV2
 from dku_azure.clusters import ClusterBuilder
-from dku_azure.utils import run_and_process_cloud_error, get_instance_metadata, get_subscription_id
+from dku_azure.utils import run_and_process_cloud_error, get_instance_metadata, get_subscription_id, determine_node_pool_mode
 
 class MyCluster(Cluster):
     def __init__(self, cluster_id, cluster_name, config, plugin_config):
@@ -306,6 +306,7 @@ class MyCluster(Cluster):
         # Node pools
         install_gpu_driver = False
         gpu_node_pools_taints = set()
+        is_there_system_node_pool = False
         for idx, node_pool_conf in enumerate(self.config.get("nodePools", [])):
             node_pool_builder = cluster_builder.get_node_pool_builder()
             node_pool_builder.with_idx(idx)
@@ -328,8 +329,14 @@ class MyCluster(Cluster):
                                               min_num_nodes=node_pool_conf.get("minNumNodes", None),
                                               max_num_nodes=node_pool_conf.get("maxNumNodes", None))
 
-            node_pool_builder.with_mode(mode=node_pool_conf.get("mode", "Automatic"),
-                                        system_pods_only=node_pool_conf.get("systemPodsOnly", True))
+            input_node_pool_mode = node_pool_conf.get("mode", "Automatic")
+            applied_system_pods_only = False
+            applied_node_pool_mode = determine_node_pool_mode(node_pool_conf.get("mode", "Automatic"), is_there_system_node_pool)
+            if applied_node_pool_mode == "System":
+                is_there_system_node_pool = True
+                applied_system_pods_only = node_pool_conf.get("systemPodsOnly", True)
+            node_pool_builder.with_mode(mode=applied_node_pool_mode,
+                                        system_pods_only=applied_system_pods_only)
 
             node_pool_builder.with_disk_size_gb(disk_size_gb=node_pool_conf.get("osDiskSizeGb", 0))
             node_pool_builder.with_node_labels(node_pool_conf.get("labels", None))

--- a/python-clusters/create-aks-cluster/cluster.py
+++ b/python-clusters/create-aks-cluster/cluster.py
@@ -14,7 +14,7 @@ from dku_utils.taints import Toleration
 from dku_kube.nvidia_utils import add_gpu_driver_if_needed
 from dku_azure.auth import get_credentials_from_connection_info, get_credentials_from_connection_infoV2
 from dku_azure.clusters import ClusterBuilder
-from dku_azure.utils import run_and_process_cloud_error, get_instance_metadata, get_subscription_id, determine_node_pool_mode
+from dku_azure.utils import run_and_process_cloud_error, get_instance_metadata, get_subscription_id, determine_node_pool_mode, is_explicit_system_node_pool
 
 class MyCluster(Cluster):
     def __init__(self, cluster_id, cluster_name, config, plugin_config):
@@ -306,8 +306,9 @@ class MyCluster(Cluster):
         # Node pools
         install_gpu_driver = False
         gpu_node_pools_taints = set()
-        is_there_system_node_pool = False
-        for idx, node_pool_conf in enumerate(self.config.get("nodePools", [])):
+        node_pool_confs = [node_pool[1].get("mode", "Automatic") for node_pool in enumerate(self.config.get("nodePools", []))]
+        is_there_system_node_pool = is_explicit_system_node_pool(node_pool_confs)
+        for idx, node_pool_conf in node_pool_confs:
             node_pool_builder = cluster_builder.get_node_pool_builder()
             node_pool_builder.with_idx(idx)
             node_pool_builder.with_vm_size(node_pool_conf.get("vmSize", None))

--- a/python-clusters/create-aks-cluster/cluster.py
+++ b/python-clusters/create-aks-cluster/cluster.py
@@ -306,10 +306,9 @@ class MyCluster(Cluster):
         # Node pools
         install_gpu_driver = False
         gpu_node_pools_taints = set()
-        node_pool_confs = enumerate(self.config.get("nodePools", []))
-        node_pool_modes = [node_pool[1].get("mode", "Automatic") for node_pool in node_pool_confs]
+        node_pool_modes = [node_pool[1].get("mode", "Automatic") for node_pool in enumerate(self.config.get("nodePools", []))]
         is_there_system_node_pool = is_explicit_system_node_pool(node_pool_modes)
-        for idx, node_pool_conf in node_pool_confs:
+        for idx, node_pool_conf in enumerate(self.config.get("nodePools", [])):
             node_pool_builder = cluster_builder.get_node_pool_builder()
             node_pool_builder.with_idx(idx)
             node_pool_builder.with_vm_size(node_pool_conf.get("vmSize", None))

--- a/python-clusters/create-aks-cluster/cluster.py
+++ b/python-clusters/create-aks-cluster/cluster.py
@@ -330,13 +330,11 @@ class MyCluster(Cluster):
                                               max_num_nodes=node_pool_conf.get("maxNumNodes", None))
 
             input_node_pool_mode = node_pool_conf.get("mode", "Automatic")
-            applied_system_pods_only = False
             applied_node_pool_mode = determine_node_pool_mode(node_pool_conf.get("mode", "Automatic"), is_there_system_node_pool)
             if applied_node_pool_mode == "System":
                 is_there_system_node_pool = True
-                applied_system_pods_only = node_pool_conf.get("systemPodsOnly", True)
             node_pool_builder.with_mode(mode=applied_node_pool_mode,
-                                        system_pods_only=applied_system_pods_only)
+                                        system_pods_only=node_pool_conf.get("systemPodsOnly", True))
 
             node_pool_builder.with_disk_size_gb(disk_size_gb=node_pool_conf.get("osDiskSizeGb", 0))
             node_pool_builder.with_node_labels(node_pool_conf.get("labels", None))

--- a/python-clusters/create-aks-cluster/cluster.py
+++ b/python-clusters/create-aks-cluster/cluster.py
@@ -306,8 +306,9 @@ class MyCluster(Cluster):
         # Node pools
         install_gpu_driver = False
         gpu_node_pools_taints = set()
-        node_pool_confs = [node_pool[1].get("mode", "Automatic") for node_pool in enumerate(self.config.get("nodePools", []))]
-        is_there_system_node_pool = is_explicit_system_node_pool(node_pool_confs)
+        node_pool_confs = enumerate(self.config.get("nodePools", []))
+        node_pool_modes = [node_pool[1].get("mode", "Automatic") for node_pool in node_pool_confs]
+        is_there_system_node_pool = is_explicit_system_node_pool(node_pool_modes)
         for idx, node_pool_conf in node_pool_confs:
             node_pool_builder = cluster_builder.get_node_pool_builder()
             node_pool_builder.with_idx(idx)

--- a/python-lib/dku_azure/clusters.py
+++ b/python-lib/dku_azure/clusters.py
@@ -303,10 +303,7 @@ class NodePoolBuilder(object):
 
     def build(self):
         agent_pool_profile_params = {}
-        if self.mode == "Automatic":
-            agent_pool_profile_params["mode"] = "System"
-        else:
-            agent_pool_profile_params["mode"] = self.mode
+        agent_pool_profile_params["mode"] = self.mode
         agent_pool_profile_params["name"] = "nodepool{}".format(self.idx)
         agent_pool_profile_params["type"] = self.agent_pool_type
         agent_pool_profile_params["vm_size"] = self.vm_size

--- a/python-lib/dku_azure/clusters.py
+++ b/python-lib/dku_azure/clusters.py
@@ -303,7 +303,7 @@ class NodePoolBuilder(object):
 
     def build(self):
         agent_pool_profile_params = {}
-        if self.mode == "Automatic" and self.idx == 0:
+        if self.mode == "Automatic":
             agent_pool_profile_params["mode"] = "System"
         else:
             agent_pool_profile_params["mode"] = self.mode

--- a/python-lib/dku_azure/utils.py
+++ b/python-lib/dku_azure/utils.py
@@ -95,12 +95,6 @@ def get_host_network(credentials=None, resource_group=None, connection_info=None
     logging.info("SUBNET ID: {}".format(subnet_id))
     return vnet, subnet_id
 
-def is_existing_system_node_pool(existing_node_pool_modes):
-    is_existing_system_node_pool = False
-    for node_pool_mode in existing_node_pool_modes:
-        is_existing_system_node_pool = is_existing_system_node_pool or node_pool_mode == "System"
-    return is_existing_system_node_pool
-
 def determine_node_pool_mode(input_node_pool_mode, is_existing_system_node_pool):
     if input_node_pool_mode != "Automatic":
         return input_node_pool_mode

--- a/python-lib/dku_azure/utils.py
+++ b/python-lib/dku_azure/utils.py
@@ -94,3 +94,17 @@ def get_host_network(credentials=None, resource_group=None, connection_info=None
     logging.info("VNET: {}".format(vnet))
     logging.info("SUBNET ID: {}".format(subnet_id))
     return vnet, subnet_id
+
+def is_existing_system_node_pool(existing_node_pool_modes):
+    is_existing_system_node_pool = False
+    for node_pool_mode in existing_node_pool_modes:
+        is_existing_system_node_pool = is_existing_system_node_pool or node_pool_mode == "System"
+    return is_existing_system_node_pool
+
+def determine_node_pool_mode(input_node_pool_mode, is_existing_system_node_pool):
+    if input_node_pool_mode != "Automatic":
+        return input_node_pool_mode
+    if is_existing_system_node_pool:
+        return "User"
+    else:
+        return "System"

--- a/python-lib/dku_azure/utils.py
+++ b/python-lib/dku_azure/utils.py
@@ -104,7 +104,4 @@ def determine_node_pool_mode(input_node_pool_mode, is_existing_system_node_pool)
         return "System"
 
 def is_explicit_system_node_pool(node_pool_modes):
-    for node_pool_mode in node_pool_modes:
-        if node_pool_mode == "System":
-            return True
-    return False
+    return "System" in node_pool_modes

--- a/python-lib/dku_azure/utils.py
+++ b/python-lib/dku_azure/utils.py
@@ -102,3 +102,9 @@ def determine_node_pool_mode(input_node_pool_mode, is_existing_system_node_pool)
         return "User"
     else:
         return "System"
+
+def is_explicit_system_node_pool(node_pool_modes):
+    for node_pool_mode in node_pool_modes:
+        if node_pool_mode == "System":
+            return True
+    return False

--- a/python-runnables/add-node-pool/runnable.py
+++ b/python-runnables/add-node-pool/runnable.py
@@ -3,7 +3,7 @@ import json, logging
 from dku_utils.cluster import get_cluster_from_dss_cluster
 from dku_utils.taints import Toleration
 from dku_azure.clusters import NodePoolBuilder
-from dku_azure.utils import run_and_process_cloud_error, get_instance_metadata, get_subscription_id
+from dku_azure.utils import run_and_process_cloud_error, get_instance_metadata, get_subscription_id, is_existing_system_node_pool, determine_node_pool_mode
 from dku_kube.nvidia_utils import add_gpu_driver_if_needed
 
 class MyRunnable(Runnable):
@@ -97,7 +97,7 @@ class MyRunnable(Runnable):
                                           min_num_nodes=node_pool_config.get("minNumNodes", None),
                                           max_num_nodes=node_pool_config.get("maxNumNodes", None))
 
-        node_pool_builder.with_mode(mode=node_pool_config.get("mode", "Automatic"),
+        node_pool_builder.with_mode(mode=determine_node_pool_mode(node_pool_config.get("mode", "Automatic"), is_existing_system_node_pool([node_pool.mode for node_pool in node_pools])),
                                     system_pods_only=node_pool_config.get("systemPodsOnly", True))
 
         node_pool_builder.with_disk_size_gb(disk_size_gb=node_pool_config.get("osDiskSizeGb", 0))

--- a/python-runnables/add-node-pool/runnable.py
+++ b/python-runnables/add-node-pool/runnable.py
@@ -3,7 +3,7 @@ import json, logging
 from dku_utils.cluster import get_cluster_from_dss_cluster
 from dku_utils.taints import Toleration
 from dku_azure.clusters import NodePoolBuilder
-from dku_azure.utils import run_and_process_cloud_error, get_instance_metadata, get_subscription_id, is_existing_system_node_pool, determine_node_pool_mode
+from dku_azure.utils import run_and_process_cloud_error, get_instance_metadata, get_subscription_id
 from dku_kube.nvidia_utils import add_gpu_driver_if_needed
 
 class MyRunnable(Runnable):
@@ -98,6 +98,9 @@ class MyRunnable(Runnable):
                                           max_num_nodes=node_pool_config.get("maxNumNodes", None))
 
         input_node_pool_mode = node_pool_config.get("mode", "Automatic")
+        # The cluster cannot be created without a System node pool (error raised),
+        # deleting the last System node pool is not possible (error raised),
+        # so adding an Automatic node pool will always result in adding a User node pool
         applied_node_pool_mode = "User" if input_node_pool_mode == "Automatic" else input_node_pool_mode
         node_pool_builder.with_mode(mode=applied_node_pool_mode,
                                     system_pods_only=node_pool_config.get("systemPodsOnly", True))

--- a/python-runnables/add-node-pool/runnable.py
+++ b/python-runnables/add-node-pool/runnable.py
@@ -97,7 +97,9 @@ class MyRunnable(Runnable):
                                           min_num_nodes=node_pool_config.get("minNumNodes", None),
                                           max_num_nodes=node_pool_config.get("maxNumNodes", None))
 
-        node_pool_builder.with_mode(mode=determine_node_pool_mode(node_pool_config.get("mode", "Automatic"), is_existing_system_node_pool([node_pool.mode for node_pool in node_pools])),
+        input_node_pool_mode = node_pool_config.get("mode", "Automatic")
+        applied_node_pool_mode = "User" if input_node_pool_mode == "Automatic" else input_node_pool_mode
+        node_pool_builder.with_mode(mode=applied_node_pool_mode,
                                     system_pods_only=node_pool_config.get("systemPodsOnly", True))
 
         node_pool_builder.with_disk_size_gb(disk_size_gb=node_pool_config.get("osDiskSizeGb", 0))


### PR DESCRIPTION
When creating a node pool on a cluster, the following applies:
* there needs to be at least one `System` node pool
* an invalid node pool mode is not accepted anymore by Azure

On DSS side, we offer an `Automatic` node pool mode that should behave as:
* if there is already one `System` node pool in the cluster, the new `Automatic` one will be `User`
* if there is no `System` node pool in the cluster, the new `Automatic` one needs to be `System`